### PR TITLE
refactor: change dashboard/course about exceptions naming for clarity

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,18 @@ Change Log
    in this file.  It adheres to the structure of https://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
 ~~~~~~~~~~
+
+[0.6.2] - 2022-04-07
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Change dashboard/course about render exceptions naming for clarity
 
 [0.6.1] - 2022-04-07
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -275,7 +275,7 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
             """
             super().__init__(message, redirect_to=redirect_to)
 
-    class RenderAlternativeCourseAbout(OpenEdxFilterException):
+    class RenderInvalidCourseAbout(OpenEdxFilterException):
         """
         Custom class used to stop the course about rendering process.
         """
@@ -348,7 +348,7 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
             """
             super().__init__(message, redirect_to=redirect_to)
 
-    class RenderAlternativeDashboard(OpenEdxFilterException):
+    class RenderInvalidDashboard(OpenEdxFilterException):
         """
         Custom class used to stop the dashboard render process.
         """

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -310,7 +310,7 @@ class TestRenderingFilters(TestCase):
     @data(
         (DashboardRenderStarted.RedirectToPage, {"redirect_to": "custom-dashboard.html"}),
         (
-            DashboardRenderStarted.RenderAlternativeDashboard,
+            DashboardRenderStarted.RenderInvalidDashboard,
             {
                 "dashboard_template": "custom-dasboard.html",
                 "template_context": {"user": Mock()},
@@ -333,7 +333,7 @@ class TestRenderingFilters(TestCase):
     @data(
         (CourseAboutRenderStarted.RedirectToPage, {"redirect_to": "custom-course-about.html"}),
         (
-            CourseAboutRenderStarted.RenderAlternativeCourseAbout,
+            CourseAboutRenderStarted.RenderInvalidCourseAbout,
             {
                 "course_about_template": "custom-course-about.html",
                 "template_context": {"course_id": Mock()},


### PR DESCRIPTION
**Description:** this PR change naming of some exceptions to avoid confusion with rendering valid/invalid templates. This addresses [this](https://github.com/openedx/edx-platform/pull/29994#discussion_r848065064) comment in filters PRs.