### PR TITLE
[BB-6206] Introduce a Filter to hook into courseware XBlock rendering

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -451,13 +451,17 @@ class XBlockRenderStarted(OpenEdxPublicFilter):
             super().__init__( message, response=response)
 
     @classmethod
-    def run_filter(cls, context, template_name):
+    def run_filter(cls, block, context, template_name):
         """
         Execute the filter with the context.
 
         Arguments:
+            block (VerticalBlock): The VerticalBlock containing the XBlocks to be
+                rendered
             context (dict): the xblock rendering context with fragment and all other
                 related values.
+            template_name (str): the name of the template that will render the final
+                view
         """
-        data = super().run_pipeline(context=context, template_name=template_name)
+        data = super().run_pipeline(block=block, context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -422,3 +422,42 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
+
+
+class XBlockRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class to change the XBlock Fragment of the units before rendering it to response
+
+    Arguments:
+        context (dict): contains the full context object that will be rendered in the
+        template_name (str): path to the template being used for rendering the XBlock
+            defaults to `lms/templates/courseware/courseware-chromeless.html`
+    """
+
+    filter_type = "org.openedx.learning.xblock.render.started.v1"
+
+    class RenderCustomReponse(OpenEdxFilterException):
+        """
+        Custom class used to stop the XBlock rendering process
+        """
+        def __init__(self, message, response=None):
+            """
+            Override init that defines specific arguments used in the XBlock render process.
+
+            Arguments:
+                message: error message for the exception.
+                response: custom response which will be returned by the render_xblock view.
+            """
+            super().__init__( message, response=response)
+
+    @classmethod
+    def run_filter(cls, context, template_name):
+        """
+        Execute the filter with the context.
+
+        Arguments:
+            context (dict): the xblock rendering context with fragment and all other
+                related values.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")


### PR DESCRIPTION
**Description:** 

The PR introduces a new filter named `XBlockRenderStarted` that allows apps to modify the output of the XBlock using pipelines. The corresponding change in the platform is introduced in https://github.com/openedx/edx-platform/pull/30650

**JIRA:**

OpenCraft JIRA - https://tasks.opencraft.com/browse/BB-6206

**Dependencies:** 
- Hook call in edx-platform - https://github.com/openedx/edx-platform/pull/30650

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** 
Nothing specific

**Testing instructions:**

The example application using this Hook is implemented in [openedx-edit-link](https://github.com/open-craft/openedx-edit-links/pull/1) and its PR contains the testing instructions.

**Reviewers:**
- [ ] @navinkarkera
- [ ] @mariajgrimaldi  - Hi, will you be kind enough to review this once @navinkarkera has taken a pass?

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
None