### PR TITLE
feat: adds the VerticalBlockChildRenderStarted filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[0.8.0] - 2022-08-18
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* VerticalBlockChildRenderStarted filter added that is called when every child block of a VericalBlock is about to be rendered.
 
 [0.7.0] - 2022-05-26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -422,3 +422,23 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
+
+
+class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create vertical block children's render filters.
+    """
+
+    filter_type = "org.openedx.learning.vertical_block_child.render.started.v1"
+
+    @classmethod
+    def run_filter(cls, block, context):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            block (XBlock): the XBlock that is about to be rendered into HTML
+            context (dict): rendering context values like is_mobile_app, show_title..etc
+        """
+        data = super().run_pipeline(block=block, context=context)
+        return data.get("block"), data.get("context")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -17,6 +17,7 @@ from openedx_filters.learning.filters import (
     DashboardRenderStarted,
     StudentLoginRequested,
     StudentRegistrationRequested,
+    VerticalBlockChildRenderStarted,
 )
 
 
@@ -272,6 +273,7 @@ class TestRenderingFilters(TestCase):
 
     - CourseAboutRenderStarted
     - DashboardRenderStarted
+    - VerticalBlockChildRenderStarted
     """
 
     def setUp(self):
@@ -353,6 +355,26 @@ class TestRenderingFilters(TestCase):
         exception = course_about_exception(message="You can't access the course about", **attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    def test_verticalblock_child_render_started(self):
+        """
+        Test VerticalBlockChildRenderStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return the child block and its context in that order.
+        """
+        block = Mock("child_block")
+        context = {
+            "is_mobile_view": False,
+            "username": "edx",
+            "child_of_veritcal": True,
+            "bookmarked": False
+        }
+
+        result = VerticalBlockChildRenderStarted.run_filter(block, context)
+
+        self.assertTupleEqual((block, context,), result)
 
 
 class TestCohortFilters(TestCase):


### PR DESCRIPTION
**Description:**

This adds the `VerticalBlockChildRenderStarted` filter which passes the child XBlock and it's rendering context dictionary to the filter allowing the filter pipeline to react to the content of the XBlock based on the context.

This is a follow up of the PoC implemented in PR  #35. The filter attempted in the previous PR was poorly placed and was limiting. The filter introduced in this PR provides a better opportunity for plugin's to enhance the experience based on the XBlock being rendered.

The Edit Links PR https://github.com/open-craft/openedx-edit-links/pull/1 shows one such use-case of adding extra HTML to the content of HTML Block before rendering.

**JIRA:** Link to JIRA ticket

**Dependencies:**

- https://github.com/openedx/edx-platform/pull/30773

**Merge deadline:** NA

**Installation instructions:**

Ensure that `edx-platform` is checked out to branch of https://github.com/openedx/edx-platform/pull/30773

**Testing instructions:**

Unit tests are added for the filter. For full feature test, follow testing instructions from https://github.com/open-craft/openedx-edit-links/pull/1

**Reviewers:**
- [x] @navinkarkera
- [x] @mariajgrimaldi 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
NA
