### PR TITLE
feat: add filter before user setttings context is rendered

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ Change Log
 
 Unreleased
 ----------
+[1.2.0] - 2023-03-01
+--------------------
+
+Added
+~~~~~
+
+* AccountSettingsRenderStarted filter added which can be used to modify the rendered output of the account settings page.
+
 [1.1.0] - 2023-02-16
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -29,7 +29,6 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
             """
             super().__init__(message, redirect_to=redirect_to)
 
-
     class RenderInvalidAccountSettings(OpenEdxFilterException):
         """
         Custom class used to stop the account settings rendering process.

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1,9 +1,50 @@
 """
 Package where filters related to the learning architectural subdomain are implemented.
 """
+
 from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.tooling import OpenEdxPublicFilter
 from openedx_filters.utils import SensitiveDataManagementMixin
+
+
+class AccountSettingsRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create Account settings filters.
+    """
+
+    filter_type = "org.openedx.learning.student.settings.render.started.v1"
+
+    class PreventAccountSettingsRender(OpenEdxFilterException):
+        """
+        Custom class used to stop the Account settings rendering process.
+        """
+
+    class RedirectToPage(OpenEdxFilterException):
+        """
+        Custom class used to redirect before account settings rendering process.
+        """
+
+        def __init__(self, message, redirect_to=""):
+            """
+            Override init that defines specific arguments used in the account settings render process.
+
+            Arguments:
+                message: error message for the exception.
+                redirect_to: URL to redirect to.
+            """
+            super().__init__(message, redirect_to=redirect_to)
+
+    @classmethod
+    def run_filter(cls, context):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context for the account settings page.
+        """
+        data = super().run_pipeline(context=context)
+        context = data.get("context")
+        return context
 
 
 class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementMixin):

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -47,10 +47,7 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
                 message: error message for the exception.
                 response: custom response which will be returned by the account settings view.
             """
-            super().__init__(
-                message,
-                response=response,
-            )
+            super().__init__(message, response=response)
 
     @classmethod
     def run_filter(cls, context):

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -66,16 +66,16 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
             super().__init__(message, response=response)
 
     @classmethod
-    def run_filter(cls, context):
+    def run_filter(cls, context, template_name):
         """
         Execute a filter with the signature specified.
 
         Arguments:
             context (dict): template context for the account settings page.
+            template_name (str): template path used to render the account settings page.
         """
-        data = super().run_pipeline(context=context)
-        context = data.get("context")
-        return context
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")
 
 
 class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementMixin):

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -21,7 +21,7 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
 
     class RedirectToPage(OpenEdxFilterException):
         """
-        Custom class used to redirect before account settings rendering process.
+        Custom class used to redirect before the account settings rendering process.
         """
 
         def __init__(self, message, redirect_to=""):
@@ -33,6 +33,24 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
                 redirect_to: URL to redirect to.
             """
             super().__init__(message, redirect_to=redirect_to)
+
+    class RenderCustomResponse(OpenEdxFilterException):
+        """
+        Custom class used to stop the account settings rendering process and return a custom response.
+        """
+
+        def __init__(self, message, response=None):
+            """
+            Override init that defines specific arguments used in the account settings render process.
+
+            Arguments:
+                message: error message for the exception.
+                response: custom response which will be returned by the account settings view.
+            """
+            super().__init__(
+                message,
+                response=response,
+            )
 
     @classmethod
     def run_filter(cls, context):

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -40,7 +40,7 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
         Execute a filter with the signature specified.
 
         Arguments:
-            context (dict): context for the account settings page.
+            context (dict): template context for the account settings page.
         """
         data = super().run_pipeline(context=context)
         context = data.get("context")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -14,11 +14,6 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
 
     filter_type = "org.openedx.learning.student.settings.render.started.v1"
 
-    class PreventAccountSettingsRender(OpenEdxFilterException):
-        """
-        Custom class used to stop the Account settings rendering process.
-        """
-
     class RedirectToPage(OpenEdxFilterException):
         """
         Custom class used to redirect before the account settings rendering process.
@@ -33,6 +28,27 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
                 redirect_to: URL to redirect to.
             """
             super().__init__(message, redirect_to=redirect_to)
+
+
+    class RenderInvalidAccountSettings(OpenEdxFilterException):
+        """
+        Custom class used to stop the account settings rendering process.
+        """
+
+        def __init__(self, message, account_settings_template="", template_context=None):
+            """
+            Override init that defines specific arguments used in the account settings render process.
+
+            Arguments:
+                message: error message for the exception.
+                account_settings_template: template path rendered instead.
+                template_context: context used to the new account settings template.
+            """
+            super().__init__(
+                message,
+                account_settings_template=account_settings_template,
+                template_context=template_context,
+            )
 
     class RenderCustomResponse(OpenEdxFilterException):
         """

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -496,7 +496,7 @@ class TestRenderingFilters(TestCase):
         (AccountSettingsRenderStarted.RenderCustomResponse, {"response": Mock()})
     )
     @unpack
-    def test_halt_certificate_process(self, AccountSettingsException, attributes):
+    def test_halt_account_rendering_process(self, AccountSettingsException, attributes):
         """
         Test for account settings exceptions attributes.
         Expected behavior:

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -7,6 +7,7 @@ from ddt import data, ddt, unpack
 from django.test import TestCase
 
 from openedx_filters.learning.filters import (
+    AccountSettingsRenderStarted,
     CertificateCreationRequested,
     CertificateRenderStarted,
     CohortAssignmentRequested,
@@ -309,6 +310,7 @@ class TestRenderingFilters(TestCase):
     - DashboardRenderStarted
     - VerticalBlockChildRenderStarted
     - VerticalBlockRenderCompleted
+    - AccountSettingsRenderStarted
     """
 
     def setUp(self):
@@ -471,6 +473,22 @@ class TestRenderingFilters(TestCase):
         exception = render_exception(**attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
+    def test_account_settings_render_started(self):
+        """
+        Test AccountSettingsRenderStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return context.
+        """
+        context = {
+            'duplicate_provider': None,
+            'disable_courseware_js': True,
+            'show_dashboard_tabs': True
+        }
+
+        result = AccountSettingsRenderStarted.run_filter(context=context)
+
+        self.assertEqual(result, context)
 
 
 class TestCohortFilters(TestCase):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -473,6 +473,7 @@ class TestRenderingFilters(TestCase):
         exception = render_exception(**attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
+
     def test_account_settings_render_started(self):
         """
         Test AccountSettingsRenderStarted filter behavior under normal conditions.
@@ -486,13 +487,13 @@ class TestRenderingFilters(TestCase):
             'show_dashboard_tabs': True
         }
 
-        result = AccountSettingsRenderStarted.run_filter(context=context)
+        result, _ = AccountSettingsRenderStarted.run_filter(context=context, template_name=None)
 
         self.assertEqual(result, context)
 
     @data(
         (AccountSettingsRenderStarted.RedirectToPage, {"redirect_to": "custom_account_settings.html"}),
-        (AccountSettingsRenderStarted.PreventAccountSettingsRender, {}),
+        (AccountSettingsRenderStarted.RenderInvalidAccountSettings, {}),
         (AccountSettingsRenderStarted.RenderCustomResponse, {"response": Mock()})
     )
     @unpack

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -492,7 +492,8 @@ class TestRenderingFilters(TestCase):
 
     @data(
         (AccountSettingsRenderStarted.RedirectToPage, {"redirect_to": "custom_account_settings.html"}),
-        (AccountSettingsRenderStarted.PreventAccountSettingsRender, {})
+        (AccountSettingsRenderStarted.PreventAccountSettingsRender, {}),
+        (AccountSettingsRenderStarted.RenderCustomResponse, {"response": Mock()})
     )
     @unpack
     def test_halt_certificate_process(self, AccountSettingsException, attributes):
@@ -501,7 +502,7 @@ class TestRenderingFilters(TestCase):
         Expected behavior:
             - The exception must have the attributes specified.
         """
-        exception = AccountSettingsException(message="You can't access to this page", **attributes)
+        exception = AccountSettingsException(message="You can't access this page", **attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
 

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -490,6 +490,21 @@ class TestRenderingFilters(TestCase):
 
         self.assertEqual(result, context)
 
+    @data(
+        (AccountSettingsRenderStarted.RedirectToPage, {"redirect_to": "custom_account_settings.html"}),
+        (AccountSettingsRenderStarted.PreventAccountSettingsRender, {})
+    )
+    @unpack
+    def test_halt_certificate_process(self, AccountSettingsException, attributes):
+        """
+        Test for account settings exceptions attributes.
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = AccountSettingsException(message="You can't access to this page", **attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
 
 class TestCohortFilters(TestCase):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = True
 tag = True
 


### PR DESCRIPTION
**Description:** This PR is to add one filter:

`AccountSettingsRenderStarted` filter which passes the account settings context before is  rendered.

**JIRA:** 
No direct openedx related ticket is available. Related tickets that add context to this change are:
- [DS-303](https://edunext.atlassian.net/browse/DS-303)

**Dependencies:** 
  - https://github.com/openedx/edx-platform/pull/31295 Hook PR in edx-platform.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

The example application using this filter is implemented in [edunext-platoform](https://github.com/eduNEXT/edunext-platform/pull/691) and its PR contains the testing instructions.

**Reviewers:**
- [x] @mariajgrimaldi 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None
