### PR TITLE
feat: adds the CourseEnrollmentSiteFilterRequested filter

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -442,3 +442,22 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(block=block, context=context)
         return data.get("block"), data.get("context")
+
+
+class CourseEnrollmentSiteFilterRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to filter user's course enrollments by site.
+    """
+
+    filter_type = "org.openedx.learning.course_enrollments_site.filter.requested.v1"
+
+    @classmethod
+    def run_filter(cls, context):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+        context (QuerySet): list of all user's course enrollments
+        """
+        data = super().run_pipeline(context=context)
+        return data.get("context")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -451,9 +451,9 @@ class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
 
     filter_type = "org.openedx.learning.course_enrollment_queryset.requested.v1"
 
-    class PreventCourseEnrollmentQueryset(OpenEdxFilterException):
+    class PreventEnrollmentQuerysetRequest(OpenEdxFilterException):
         """
-        Custom class used to stop the course enrollment queryset filter process.
+        Custom class used to stop the course enrollment queryset request process.
         """
 
     @classmethod

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -444,25 +444,27 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
         return data.get("block"), data.get("context")
 
 
-class CourseEnrollmentSiteFilterRequested(OpenEdxPublicFilter):
+class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
     """
-    Custom class used to filter user's course enrollments by site.
+    Custom class used to filter user's course enrollments by site, when a request is made by the user.
+    Basically it modifies the enrollments queryset.
     """
 
-    filter_type = "org.openedx.learning.course_enrollments_site.filter.requested.v1"
+    filter_type = "org.openedx.learning.course_enrollment_queryset.requested.v1"
 
     class PreventEnrollmentSiteFilter(OpenEdxFilterException):
         """
         Custom class used to stop the course enrollment site filter process.
+        This does not modify the enrollments queryset.
         """
 
     @classmethod
-    def run_filter(cls, context):
+    def run_filter(cls, enrollments):
         """
         Execute a filter with the signature specified.
 
         Arguments:
-        context (QuerySet): list of all user's course enrollments
+        enrollments (QuerySet): data with all user's course enrollments
         """
-        data = super().run_pipeline(context=context)
-        return data.get("context")
+        data = super().run_pipeline(enrollments=enrollments)
+        return data.get("enrollments")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -451,6 +451,11 @@ class CourseEnrollmentSiteFilterRequested(OpenEdxPublicFilter):
 
     filter_type = "org.openedx.learning.course_enrollments_site.filter.requested.v1"
 
+    class PreventEnrollmentSiteFilter(OpenEdxFilterException):
+        """
+        Custom class used to stop the course enrollment site filter process.
+        """
+
     @classmethod
     def run_filter(cls, context):
         """

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -446,16 +446,14 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
 
 class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
     """
-    Custom class used to filter user's course enrollments by site, when a request is made by the user.
-    Basically it modifies the enrollments queryset.
+    Custom class used to create course enrollments queryset filters and its custom methods.
     """
 
     filter_type = "org.openedx.learning.course_enrollment_queryset.requested.v1"
 
-    class PreventEnrollmentSiteFilter(OpenEdxFilterException):
+    class PreventCourseEnrollmentQueryset(OpenEdxFilterException):
         """
-        Custom class used to stop the course enrollment site filter process.
-        This does not modify the enrollments queryset.
+        Custom class used to stop the course enrollment queryset filter process.
         """
 
     @classmethod

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -279,6 +279,24 @@ class TestEnrollmentFilters(TestCase):
 
         self.assertEqual(expected_enrollments, enrollments)
 
+    @data(
+        (
+            CourseEnrollmentQuerysetRequested.PreventEnrollmentQuerysetRequest,
+            {"message": "Can't request QuerySet Enrollment."}
+        )
+    )
+    @unpack
+    def test_halt_queryset_request(self, request_exception, attributes):
+        """
+        Test for queryset request exceptions attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = request_exception(**attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
 
 @ddt
 class TestRenderingFilters(TestCase):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -12,6 +12,7 @@ from openedx_filters.learning.filters import (
     CohortAssignmentRequested,
     CohortChangeRequested,
     CourseAboutRenderStarted,
+    CourseEnrollmentSiteFilterRequested,
     CourseEnrollmentStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
@@ -214,6 +215,7 @@ class TestEnrollmentFilters(TestCase):
 
     - CourseEnrollmentStarted
     - CourseUnenrollmentStarted
+    - CourseEnrollmentSiteFilterRequested
     """
 
     def test_course_enrollment_started(self):
@@ -263,6 +265,19 @@ class TestEnrollmentFilters(TestCase):
         exception = enrollment_exception(**attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    def test_course_enrollments_requested(self):
+        """
+        Test user course enrollment requested filter.
+
+        Expected behavior:
+            - The filter should return the enrollments to orgs.
+        """
+        expected_enrollments = Mock()
+
+        enrollments = CourseEnrollmentSiteFilterRequested.run_filter(expected_enrollments)
+
+        self.assertEqual(expected_enrollments, enrollments)
 
 
 @ddt

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -12,7 +12,7 @@ from openedx_filters.learning.filters import (
     CohortAssignmentRequested,
     CohortChangeRequested,
     CourseAboutRenderStarted,
-    CourseEnrollmentSiteFilterRequested,
+    CourseEnrollmentQuerysetRequested,
     CourseEnrollmentStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
@@ -215,7 +215,7 @@ class TestEnrollmentFilters(TestCase):
 
     - CourseEnrollmentStarted
     - CourseUnenrollmentStarted
-    - CourseEnrollmentSiteFilterRequested
+    - CourseEnrollmentQuerysetRequested
     """
 
     def test_course_enrollment_started(self):
@@ -275,7 +275,7 @@ class TestEnrollmentFilters(TestCase):
         """
         expected_enrollments = Mock()
 
-        enrollments = CourseEnrollmentSiteFilterRequested.run_filter(expected_enrollments)
+        enrollments = CourseEnrollmentQuerysetRequested.run_filter(expected_enrollments)
 
         self.assertEqual(expected_enrollments, enrollments)
 


### PR DESCRIPTION
**Description:** 

This adds the ``CourseEnrollmentSiteFilterRequested`` filter which receive a Query Set context with enrollments information to allowing the filter pipeline to return the information that we need to filter.

An example of use is in [eox-tenant](https://github.com/eduNEXT/eox-tenant) custom filter step [pipeline](https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/filters/pipeline.py), where it takes the enrollments information and is filtered by tenant request, returning only the enrollments in the current site for the user.

**JIRA:** N/A

**Dependencies:**

- https://github.com/openedx/edx-platform/pull/31331

**Merge deadline:** N/A

**Installation instructions:** 

Be sure to use ``edx-platform`` branch with changes https://github.com/openedx/edx-platform/pull/31331

**Testing instructions:**

The change can be tested with testing instructions in [eox-tenant plugin](https://github.com/eduNEXT/eox-tenant/pull/156).

**Reviewers:**
- [ ] @mariajgrimaldi 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
