### PR TITLE
build: add upgrade python requirements bot

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -1,0 +1,27 @@
+name: Upgrade Python Requirements
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Target branch against which to create requirements PR"
+        required: true
+        default: 'main'
+
+jobs:
+  call-upgrade-python-requirements-workflow:
+    uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
+    with:
+      branch: ${{ github.event.inputs.branch || 'main' }}
+      # optional parameters below; fill in if you'd like github or email notifications
+      # user_reviewers: ""
+      team_reviewers: "hooks-extension-framework"
+      # email_address: ""
+      # send_success_notification: false
+    secrets:
+      requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
+      requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
+      edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
+      edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}


### PR DESCRIPTION
**Description:**
This PR adds a github action which opens a PR updating python requirements in a weekly manner tagging the hooks-extension-framework team as reviewers.

Reference: https://github.com/openedx/openedx-events/pull/106

**Github issue**
https://github.com/openedx/openedx-filters/issues/40

**Merge deadline:** 
As soon as possible.

**Reviewers:**
- [ ] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)