### PR TITLE
feat: adds VerticalBlockRenderCompleted filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,18 @@ Change Log
 
 Unreleased
 ----------
+[1.1.0] - 2023-02-16
+--------------------
+
+Added
+~~~~~
+
+* VerticalBlockRenderCompleted filter added which can be used to modify the rendered output of a VerticalBlock.
+
+Changed
+~~~~~~~
+
+* Introduced PreventChildBlockRender exception to the VerticalBlockChildRenderStarted filter.
 
 [1.0.0] - 2023-01-18
 --------------------

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1,6 +1,7 @@
 """ Package where filters related to the learning architectural subdomain are implemented.
 """
-from openedx_filters.exceptions import OpenEdxFilterException from openedx_filters.tooling import OpenEdxPublicFilter
+from openedx_filters.exceptions import OpenEdxFilterException
+from openedx_filters.tooling import OpenEdxPublicFilter
 from openedx_filters.utils import SensitiveDataManagementMixin
 
 

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1,8 +1,6 @@
+""" Package where filters related to the learning architectural subdomain are implemented.
 """
-Package where filters related to the learning architectural subdomain are implemented.
-"""
-from openedx_filters.exceptions import OpenEdxFilterException
-from openedx_filters.tooling import OpenEdxPublicFilter
+from openedx_filters.exceptions import OpenEdxFilterException from openedx_filters.tooling import OpenEdxPublicFilter
 from openedx_filters.utils import SensitiveDataManagementMixin
 
 
@@ -468,22 +466,22 @@ class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
         return data.get("enrollments")
 
 
-class VerticalBlockChildrenLoaded(OpenEdxPublicFilter):
+class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
     """
-    Custom class used to create filters that act when child blocks of a vertical block are loaded.
+    Custom class used to create filters to act on vertical block rendering completed.
     """
 
-    filter_type = "org.openedx.learning.vertical_block.children.loaded.v1"
+    filter_type = "org.openedx.learning.vertical_block.render.completed.v1"
 
     @classmethod
-    def run_filter(cls, children, context, view):
+    def run_filter(cls, fragment, context, view):
         """
         Execute a filter with the specified signature.
 
         Arguments:
-            children (list): the list of child Blocks of a vertical block
+            fragment (web_fragments.Fragment): The web-fragment containing the rendered content of VerticalBlock
             context (dict): rendering context values like is_mobile_app, show_title..etc.,
             view (str): the rendering view. Can be either 'student_view', or 'public_view'
         """
-        data = super().run_pipeline(children=children, context=context, view=view)
-        return data.get("children"), data.get("context"), data.get("view")
+        data = super().run_pipeline(fragment=fragment, context=context, view=view)
+        return data.get("fragment"), data.get("context"), data.get("view")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -466,3 +466,24 @@ class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(enrollments=enrollments)
         return data.get("enrollments")
+
+
+class VerticalBlockChildrenLoaded(OpenEdxPublicFilter):
+    """
+    Custom class used to create filters that act when child blocks of a vertical block are loaded.
+    """
+
+    filter_type = "org.openedx.learning.vertical_block.children.loaded.v1"
+
+    @classmethod
+    def run_filter(cls, children, context, view):
+        """
+        Execute a filter with the specified signature.
+
+        Arguments:
+            children (list): the list of child Blocks of a vertical block
+            context (dict): rendering context values like is_mobile_app, show_title..etc.,
+            view (str): the rendering view. Can be either 'student_view', or 'public_view'
+        """
+        data = super().run_pipeline(children=children, context=context, view=view)
+        return data.get("children"), data.get("context"), data.get("view")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -474,14 +474,15 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
     filter_type = "org.openedx.learning.vertical_block.render.completed.v1"
 
     @classmethod
-    def run_filter(cls, fragment, context, view):
+    def run_filter(cls, block, fragment, context, view):
         """
         Execute a filter with the specified signature.
 
         Arguments:
+            block (VerticalBlock): The VeriticalBlock instance which is being rendered
             fragment (web_fragments.Fragment): The web-fragment containing the rendered content of VerticalBlock
             context (dict): rendering context values like is_mobile_app, show_title..etc.,
             view (str): the rendering view. Can be either 'student_view', or 'public_view'
         """
-        data = super().run_pipeline(fragment=fragment, context=context, view=view)
-        return data.get("fragment"), data.get("context"), data.get("view")
+        data = super().run_pipeline(block=block, fragment=fragment, context=context, view=view)
+        return data.get("block"), data.get("fragment"), data.get("context"), data.get("view")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1,4 +1,5 @@
-""" Package where filters related to the learning architectural subdomain are implemented.
+"""
+Package where filters related to the learning architectural subdomain are implemented.
 """
 from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.tooling import OpenEdxPublicFilter
@@ -430,6 +431,11 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
 
     filter_type = "org.openedx.learning.vertical_block_child.render.started.v1"
 
+    class PreventChildBlockRender(OpenEdxFilterException):
+        """
+        Custom class used to stop a particular child block from being rendered.
+        """
+
     @classmethod
     def run_filter(cls, block, context):
         """
@@ -473,6 +479,11 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
     """
 
     filter_type = "org.openedx.learning.vertical_block.render.completed.v1"
+
+    class PreventVerticalBlockRender(OpenEdxFilterException):
+        """
+        Custom class used to prevent the vertical block from rendering for the user.
+        """
 
     @classmethod
     def run_filter(cls, block, fragment, context, view):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -19,6 +19,7 @@ from openedx_filters.learning.filters import (
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
+    VerticalBlockChildrenLoaded,
 )
 
 
@@ -307,6 +308,7 @@ class TestRenderingFilters(TestCase):
     - CourseAboutRenderStarted
     - DashboardRenderStarted
     - VerticalBlockChildRenderStarted
+    - VerticalBlockChildrenLoaded
     """
 
     def setUp(self):
@@ -408,6 +410,26 @@ class TestRenderingFilters(TestCase):
         result = VerticalBlockChildRenderStarted.run_filter(block, context)
 
         self.assertTupleEqual((block, context,), result)
+
+    def test_vertical_block_children_loaded(self):
+        """
+        Test VerticalBlockChildrenLoaded filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter must return a list of blocks, the context and view in order.
+        """
+        children = [Mock("block_1"), Mock("block_2"), Mock("block_3")]
+        context = {
+            "is_mobile_view": False,
+            "username": "edx",
+            "bookmarked": False
+        }
+        view = "student_view"
+
+        result = VerticalBlockChildrenLoaded.run_filter(children, context, view)
+
+        self.assertTupleEqual((children, context, view), result)
 
 
 class TestCohortFilters(TestCase):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -419,6 +419,7 @@ class TestRenderingFilters(TestCase):
             - The filter must have the signature specified.
             - The filter must return a webfragment, the context and view in order.
         """
+        block = Mock("VerticalBlock")
         fragment = Mock("webfragment")
         context = {
             "is_mobile_view": False,
@@ -427,9 +428,9 @@ class TestRenderingFilters(TestCase):
         }
         view = "student_view"
 
-        result = VerticalBlockRenderCompleted.run_filter(fragment, context, view)
+        result = VerticalBlockRenderCompleted.run_filter(block, fragment, context, view)
 
-        self.assertTupleEqual((fragment, context, view), result)
+        self.assertTupleEqual((block, fragment, context, view), result)
 
 
 class TestCohortFilters(TestCase):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -411,6 +411,26 @@ class TestRenderingFilters(TestCase):
 
         self.assertTupleEqual((block, context,), result)
 
+    @data(
+        (
+            VerticalBlockChildRenderStarted.PreventChildBlockRender,
+            {
+                "message": "Assessement question not available for Audit students"
+            }
+        )
+    )
+    @unpack
+    def test_halt_vertical_child_block_render(self, block_render_exception, attributes):
+        """
+        Test for vertical child block render exception attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = block_render_exception(**attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
     def test_vertical_block_render_completed(self):
         """
         Test VerticalBlockRenderCompleted filter behavior under normal conditions.
@@ -431,6 +451,26 @@ class TestRenderingFilters(TestCase):
         result = VerticalBlockRenderCompleted.run_filter(block, fragment, context, view)
 
         self.assertTupleEqual((block, fragment, context, view), result)
+
+    @data(
+        (
+            VerticalBlockRenderCompleted.PreventVerticalBlockRender,
+            {
+                "message": "Assignment units are not available for Audit students"
+            }
+        )
+    )
+    @unpack
+    def test_halt_vertical_block_render(self, render_exception, attributes):
+        """
+        Test for vertical child block render exception attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = render_exception(**attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
 
 
 class TestCohortFilters(TestCase):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -19,7 +19,7 @@ from openedx_filters.learning.filters import (
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
-    VerticalBlockChildrenLoaded,
+    VerticalBlockRenderCompleted,
 )
 
 
@@ -308,7 +308,7 @@ class TestRenderingFilters(TestCase):
     - CourseAboutRenderStarted
     - DashboardRenderStarted
     - VerticalBlockChildRenderStarted
-    - VerticalBlockChildrenLoaded
+    - VerticalBlockRenderCompleted
     """
 
     def setUp(self):
@@ -411,15 +411,15 @@ class TestRenderingFilters(TestCase):
 
         self.assertTupleEqual((block, context,), result)
 
-    def test_vertical_block_children_loaded(self):
+    def test_vertical_block_render_completed(self):
         """
-        Test VerticalBlockChildrenLoaded filter behavior under normal conditions.
+        Test VerticalBlockRenderCompleted filter behavior under normal conditions.
 
         Expected behavior:
             - The filter must have the signature specified.
-            - The filter must return a list of blocks, the context and view in order.
+            - The filter must return a webfragment, the context and view in order.
         """
-        children = [Mock("block_1"), Mock("block_2"), Mock("block_3")]
+        fragment = Mock("webfragment")
         context = {
             "is_mobile_view": False,
             "username": "edx",
@@ -427,9 +427,9 @@ class TestRenderingFilters(TestCase):
         }
         view = "student_view"
 
-        result = VerticalBlockChildrenLoaded.run_filter(children, context, view)
+        result = VerticalBlockRenderCompleted.run_filter(fragment, context, view)
 
-        self.assertTupleEqual((children, context, view), result)
+        self.assertTupleEqual((fragment, context, view), result)
 
 
 class TestCohortFilters(TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 tag = True
 


### PR DESCRIPTION
**Description:** 
This adds `VerticalBlockRenderCompleted` filter that will be passed the rendered fragment of a vertical block, along with the context and the view in which it was rendered. 

This will allow for changing the rendered content by the pipeline steps. 

**JIRA:** NA

**Dependencies:** 
- https://github.com/openedx/edx-platform/pull/31388

**Merge deadline:**  None

**Installation instructions:** Nothing special

**Testing instructions:**

Detailed testing instructions with a sample pipeline step are available in the edx-paltform PR: https://github.com/openedx/edx-platform/pull/31388

**Reviewers:**
- [ ] @navinkarkera 
- [ ]  @mariajgrimaldi 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

Nothing comes to mind.
