### PR TITLE
feat: adds TenantAwareLinkRenderStarted filter

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -569,3 +569,30 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(block=block, fragment=fragment, context=context, view=view)
         return data.get("block"), data.get("fragment"), data.get("context"), data.get("view")
+
+
+class TenantAwareLinkRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create tenant aware link render filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.tenant_aware_link.render.started.v1"
+
+    class PreventTenantAwarelinkRender(OpenEdxFilterException):
+        """
+        Custom class used to stop tenant aware link render process.
+        """
+
+    @classmethod
+    def run_filter(cls, context, org, val_name, default):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+        context (str): rendering context value
+        org (str): Course org filter, this value will be used to filter out the correct tenant configuration.
+        val_name (str): Name of the key for which to return configuration value.
+        default: default value to return if key is not present in the configuration
+        """
+        data = super().run_pipeline(context=context, org=org, val_name=val_name, default=default)
+        return data.get("context")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -19,6 +19,7 @@ from openedx_filters.learning.filters import (
     DashboardRenderStarted,
     StudentLoginRequested,
     StudentRegistrationRequested,
+    TenantAwareLinkRenderStarted,
     VerticalBlockChildRenderStarted,
     VerticalBlockRenderCompleted,
 )
@@ -311,6 +312,7 @@ class TestRenderingFilters(TestCase):
     - VerticalBlockChildRenderStarted
     - VerticalBlockRenderCompleted
     - AccountSettingsRenderStarted
+    - TenantAwareLinkRenderStarted
     """
 
     def setUp(self):
@@ -504,6 +506,43 @@ class TestRenderingFilters(TestCase):
             - The exception must have the attributes specified.
         """
         exception = AccountSettingsException(message="You can't access this page", **attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    def test_tenant_aware_render_started(self):
+        """
+        Test TenantAwareLinkRenderStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return tenant aware link context.
+        """
+        context = Mock()
+        org = Mock()
+        val_name = Mock()
+        default = Mock()
+
+        result = TenantAwareLinkRenderStarted.run_filter(context, org, val_name, default)
+        print(result)
+
+        self.assertEqual(context, result)
+
+    @data(
+        (
+            TenantAwareLinkRenderStarted.PreventTenantAwarelinkRender,
+            {
+                "message": "Can't render tenant aware link."
+            }
+        )
+    )
+    @unpack
+    def test_halt_tenant_aware_render(self, tenant_aware_exception, attributes):
+        """
+        Test for teant aware exceptions attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = tenant_aware_exception(**attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
 


### PR DESCRIPTION
**Description:** 

This adds the ``TenantAwareLinkRenderStarted`` filter which receive a string context with LMS url to allowing the filter pipeline to return the information that we need to filter, in this case a tenant aware link from Studio to LMS.

An example of use is in [eox-tenant](https://github.com/eduNEXT/eox-tenant) custom filter step [pipeline](https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/filters/pipeline.py), where it takes the LMS_ROOT_URL and return only the tenant aware link in the respective site.

**JIRA:** N/A

**Dependencies:**

- https://github.com/openedx/edx-platform/pull/32014

**Merge deadline:** N/A

**Installation instructions:** 

Be sure to use ``edx-platform`` branch with changes https://github.com/openedx/edx-platform/pull/32014

**Testing instructions:**

The change can be tested with testing instructions in [eox-tenant plugin](https://github.com/eduNEXT/eox-tenant/pull/156).

**Reviewers:**
- [ ] @mariajgrimaldi
- [ ] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
