### PR TITLE
fix: remove deprecated codecov package to avoid failures

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,23 +4,13 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.3
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
 platformdirs==3.2.0
     # via virtualenv
@@ -28,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -38,7 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -23,7 +23,6 @@ build==0.10.0
     #   pip-tools
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 cffi==1.15.1
@@ -34,7 +33,6 @@ chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.3
@@ -53,15 +51,11 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/quality.txt
     #   secretstorage
@@ -98,10 +92,9 @@ filelock==3.11.0
     #   virtualenv
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==6.2.1
+importlib-metadata==6.4.1
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -160,7 +153,7 @@ more-itertools==9.1.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -203,7 +196,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/quality.txt
     #   diff-cover
@@ -233,7 +226,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -260,9 +253,7 @@ readme-renderer==37.3
     #   twine
 requests==2.28.2
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   requests-toolbelt
     #   twine
 requests-toolbelt==0.10.1
@@ -273,7 +264,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.3.3
+rich==13.3.4
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -336,7 +327,6 @@ typing-extensions==4.5.0
     #   rich
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,7 +36,7 @@ coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -63,7 +63,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.2.1
+importlib-metadata==6.4.1
     # via
     #   keyring
     #   sphinx
@@ -99,7 +99,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   build
@@ -120,7 +120,7 @@ pycparser==2.21
     # via cffi
 pydata-sphinx-theme==0.12.0
     # via sphinx-book-theme
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   pydata-sphinx-theme
@@ -129,7 +129,7 @@ pygments==2.14.0
     #   sphinx
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -165,7 +165,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.3.4
     # via twine
 secretstorage==3.3.3
     # via keyring
@@ -176,7 +176,7 @@ six==1.16.0
     #   livereload
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
 sphinx==5.3.0
     # via
@@ -194,7 +194,7 @@ sphinx-book-theme==0.4.0rc1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-sphinx-copybutton==0.5.1
+sphinx-copybutton==0.5.2
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
 pip-tools==6.13.0
     # via -r requirements/pip-tools.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1
     # via -r requirements/pip.in
 setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   pylint
     #   pylint-celery
@@ -36,7 +36,7 @@ coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -56,7 +56,7 @@ exceptiongroup==1.1.1
     #   pytest
 idna==3.4
     # via requests
-importlib-metadata==6.2.1
+importlib-metadata==6.4.1
     # via
     #   keyring
     #   twine
@@ -96,7 +96,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -118,7 +118,7 @@ pycparser==2.21
     # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -136,7 +136,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -167,7 +167,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.3.4
     # via twine
 secretstorage==3.3.3
     # via keyring

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,13 +28,13 @@ jinja2==3.1.2
     # via code-annotations
 markupsafe==2.1.2
     # via jinja2
-packaging==23.0
+packaging==23.1
     # via pytest
 pbr==5.11.1
     # via stevedore
 pluggy==1.0.0
     # via pytest
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django


### PR DESCRIPTION
**Description:**
This PR removes the codecov pypi package which was deprecaded according to its the codevo.io page: https://about.codecov.io/blog/message-regarding-the-pypi-package/ 

**ISSUE:** 
https://discuss.openedx.org/t/codecov-python-package-removal/9817

**Dependencies:** 
None

**Merge deadline:** 
ASAP so new PRs don't fail

**Installation instructions:** 
Requirements files upgrade only

**Testing instructions:**
Requirements files upgrade only

**Reviewers:**
- [ ] @felipemontoya  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
codecov replacement 🤔, for more info about the current work of the replacement check: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3730931713/2023-04-14+Maintainer+s+Office+Hours+Notes
