### PR TITLE
Adding codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The following users are the maintainers of all openedx-filters
+* @openedx/hooks-extension-framework


### PR DESCRIPTION
**Description:** This PR adds a .github/CODEOWNERS file to bring the repo up to day with the maintainers program

**Dependencies:** None

**Merge deadline:** None, but hopefully soon

**Installation instructions:** None, it's all done by github

**Testing instructions:**

1. Open a PR or an issue in this Repo
2. The team @openedx/hooks-extension-framework should be tagged automatically

**Reviewers:**
- [ ] @mariajgrimaldi 


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] N/A Version bumped
- [ ] Changelog record added
- [x] N/A Documentation updated (not only docstrings)
- [x] N/A Commits are squashed

**Post merge:**
- [x] N/A Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [x] N/A Delete working branch (if not needed anymore)

**Author concerns:** Given it is a simple PR that only changes the github process lightly I have no concerns
