### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,8 +97,8 @@ html_theme_options = {
 # bug in the theme that needs to be fixed first.
 # If you'd like you can temporarily copy the logo file to your `_static`
 # directory.
-html_logo = "_static/open-edx-logo-color.png"
-html_favicon = "_static/open-edx-favicon.ico"
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,7 +4,6 @@
 -r test.txt               # Core and testing dependencies for this package
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
 build                     # Needed for twine command
 twine                     # Utility for publishing Python packages on PyPI.
 sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -53,8 +53,6 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -172,7 +170,6 @@ secretstorage==3.3.3
 six==1.16.0
     # via
     #   bleach
-    #   edx-sphinx-theme
     #   livereload
 snowballstemmer==2.2.0
     # via sphinx
@@ -182,7 +179,6 @@ sphinx==5.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
     #   pydata-sphinx-theme
     #   sphinx-autobuild
     #   sphinx-book-theme


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme.
This removes references to the deprecated theme, replaces them with the new
standard theme for the platform, and updates the theme configuraiton to use the
new theme.


**Testing instructions:**
- Run `make docs` or `make html` in the docs directory and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/public-engineering/issues/200