### PR TITLE
feat: Added a filter for modifying the course home url for externally hosted courses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ Change Log
 
 Unreleased
 ----------
+[1.3.0] - 2023-05-25
+--------------------
+
+Added
+~~~~~
+
+* CourseHomeUrlCreationStarted filter added which can be used to modify the course_home_url for externally hosted courses.
+
 [1.2.0] - 2023-03-01
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -569,3 +569,23 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(block=block, fragment=fragment, context=context, view=view)
         return data.get("block"), data.get("fragment"), data.get("context"), data.get("view")
+
+
+class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create filters to act on course home url creation.
+    """
+
+    filter_type = "org.openedx.learning.course.homepage.url.creation.started.v1"
+
+    @classmethod
+    def run_filter(cls, course_key, course_home_url):
+        """
+        Execute a filter with the specified signature.
+
+        Arguments:
+            course_key (CourseKey): The course key for which the home url is being requested.
+            course_home_url (String): The url string for the course home
+        """
+        data = super().run_pipeline(course_key=course_key, course_home_url=course_home_url)
+        return data.get("course_key"), data.get("course_home_url")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -15,6 +15,7 @@ from openedx_filters.learning.filters import (
     CourseAboutRenderStarted,
     CourseEnrollmentQuerysetRequested,
     CourseEnrollmentStarted,
+    CourseHomeUrlCreationStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
     StudentLoginRequested,
@@ -544,3 +545,26 @@ class TestCohortFilters(TestCase):
         result = CohortAssignmentRequested.run_filter(user, target_cohort)
 
         self.assertTupleEqual((user, target_cohort,), result)
+
+
+class TestFederatedContentFilters(TestCase):
+    """
+    Test class to verify standard behavior of the federated content filters.
+    You'll find test suites for:
+
+    - CourseHomeUrlCreationStarted
+    """
+
+    def test_course_homeurl_creation_started(self):
+        """
+        Test CourseHomeUrlCreationStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return course_key and course_home_url in that order.
+        """
+        course_key, course_home_url = Mock(), Mock()
+
+        result = CourseHomeUrlCreationStarted.run_filter(course_key, course_home_url)
+
+        self.assertTupleEqual((course_key, course_home_url,), result)


### PR DESCRIPTION
**Description:** This PR adds a filter for modifying the [course home url](https://github.com/openedx/edx-platform/blob/aa7370c773dcd96850fbda8e4f6ad40950c10547/openedx/features/course_experience/__init__.py#L100) for externally hosted courses

**Reference**
The URL will flow downstream to both the B2B and B2C learner dashboards. B2B enterprise-course-enrollments API gets the course_home_url via another B2C helper function get_course_run_url in edx-platform ([source](https://github.com/openedx/edx-platform/blob/ba8a3c130db5936bf0851b8db261b6c7499968e0/lms/djangoapps/course_api/api.py#L281-L293)) whereas the B2C learner home init API calls course_home_url directly ([source](https://github.com/openedx/edx-platform/blob/ba8a3c130db5936bf0851b8db261b6c7499968e0/lms/djangoapps/learner_home/serializers.py#L114-L115)).

**Reviewers:**
- [x] tag reviewer 
- [x] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

