### PR TITLE
feat: add filter design to modify the instructor dashboard render

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,16 @@ Change Log
 
 Unreleased
 ----------
+
+[1.4.0] - 2023-07-18
+--------------------
+
+Added
+~~~~~
+
+* InstructorDashboardRenderStarted filter added which can be used to modify the instructor dashboard rendering process.
+
+
 [1.3.0] - 2023-05-25
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -600,7 +600,7 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 
     class RedirectToPage(OpenEdxFilterException):
         """
-        Custom class used to stop the instructor dashboard process.
+        Custom class used to stop the instructor dashboard render by redirecting to a new page.
         """
 
         def __init__(self, message, redirect_to=""):
@@ -615,27 +615,27 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 
     class RenderInvalidDashboard(OpenEdxFilterException):
         """
-        Custom class used to stop the instructor dashboard render process.
+        Custom class used to render a custom template instead of the instructor dashboard.
         """
 
-        def __init__(self, message, dashboard_template="", template_context=None):
+        def __init__(self, message, instructor_template="", template_context=None):
             """
             Override init that defines specific arguments used in the instructor dashboard render process.
 
             Arguments:
                 message: error message for the exception.
-                dashboard_template: template path rendered instead.
-                template_context: context used to the new dashboard_template.
+                instructor_template: template path rendered instead.
+                template_context: context used to the new instructor_template.
             """
             super().__init__(
                 message,
-                dashboard_template=dashboard_template,
+                instructor_template=instructor_template,
                 template_context=template_context,
             )
 
     class RenderCustomResponse(OpenEdxFilterException):
         """
-        Custom class used to stop the instructor dashboard rendering process.
+        Custom class used to stop the instructor dashboard rendering by returning a custom response.
         """
 
         def __init__(self, message, response=None):

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -589,3 +589,76 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(course_key=course_key, course_home_url=course_home_url)
         return data.get("course_key"), data.get("course_home_url")
+
+
+class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create instructor dashboard filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.instructor.dashboard.render.started.v1"
+
+    class RedirectToPage(OpenEdxFilterException):
+        """
+        Custom class used to stop the instructor dashboard process.
+        """
+
+        def __init__(self, message, redirect_to=""):
+            """
+            Override init that defines specific arguments used in the instructor dashboard render process.
+
+            Arguments:
+                message: error message for the exception.
+                redirect_to: URL to redirect to.
+            """
+            super().__init__(message, redirect_to=redirect_to)
+
+    class RenderInvalidDashboard(OpenEdxFilterException):
+        """
+        Custom class used to stop the instructor dashboard render process.
+        """
+
+        def __init__(self, message, dashboard_template="", template_context=None):
+            """
+            Override init that defines specific arguments used in the instructor dashboard render process.
+
+            Arguments:
+                message: error message for the exception.
+                dashboard_template: template path rendered instead.
+                template_context: context used to the new dashboard_template.
+            """
+            super().__init__(
+                message,
+                dashboard_template=dashboard_template,
+                template_context=template_context,
+            )
+
+    class RenderCustomResponse(OpenEdxFilterException):
+        """
+        Custom class used to stop the instructor dashboard rendering process.
+        """
+
+        def __init__(self, message, response=None):
+            """
+            Override init that defines specific arguments used in the instructor dashboard render process.
+
+            Arguments:
+                message: error message for the exception.
+                response: custom response which will be returned by the dashboard view.
+            """
+            super().__init__(
+                message,
+                response=response,
+            )
+
+    @classmethod
+    def run_filter(cls, context, template_name):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for instructor's tab template.
+            template_name (str): template name to be rendered by the instructor's tab.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -18,6 +18,7 @@ from openedx_filters.learning.filters import (
     CourseHomeUrlCreationStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
+    InstructorDashboardRenderStarted,
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
@@ -505,6 +506,41 @@ class TestRenderingFilters(TestCase):
             - The exception must have the attributes specified.
         """
         exception = AccountSettingsException(message="You can't access this page", **attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    def test_instructor_dashboard_render_started(self):
+        """
+        Test InstructorDashboardRenderStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return context and template_name in that order.
+        """
+        result = InstructorDashboardRenderStarted.run_filter(self.context, self.template_name)
+
+        self.assertTupleEqual((self.context, self.template_name,), result)
+
+    @data(
+        (InstructorDashboardRenderStarted.RedirectToPage, {"redirect_to": "custom-dashboard.html"}),
+        (
+            InstructorDashboardRenderStarted.RenderInvalidDashboard,
+            {
+                "dashboard_template": "custom-dasboard.html",
+                "template_context": {"course": Mock()},
+            }
+        ),
+        (InstructorDashboardRenderStarted.RenderCustomResponse, {"response": Mock()}),
+    )
+    @unpack
+    def test_halt_instructor_dashboard_render(self, dashboard_exception, attributes):
+        """
+        Test for the instructor dashboard exceptions attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = dashboard_exception(message="You can't access the dashboard", **attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
 

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -526,7 +526,7 @@ class TestRenderingFilters(TestCase):
         (
             InstructorDashboardRenderStarted.RenderInvalidDashboard,
             {
-                "dashboard_template": "custom-dasboard.html",
+                "instructor_template": "custom-dasboard.html",
                 "template_context": {"course": Mock()},
             }
         ),


### PR DESCRIPTION
**Description:** 
This PR adds a new filter to modify the instructor dashboard rendering process. For example: modify the section tabs of the instructor context --that specifies which tabs to render, adding a brand new one defined in a different plugin. The use case we're currently testing is to add a new tab to the instructor dashboard, which renders management information about an Xblock.

**Installation instructions:** 
In case you want to test the use case shown here, you'll need a couple of stuff:

1. Install the LimeSurvey Xblock in the LMS/CMS services: `git+https://github.com/eduNEXT/xblock-limesurvey.git@MJG/instructor-tab`
2. Install this branch in the LMS/CMS services: `git+https://github.com/openedx/openedx-filters.git@MJG/instructor-tab-filters`
3. Change your edx-platform branch to `MJG/instructor-dashboard-filter`
4. Restart services

**Testing instructions:**

1. Add the Open edX Filters configuration to your environment: 
```
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.instructor.dashboard.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "limesurvey.extensions.filters.AddInstructorLimesurveyTab",
        ]
    },
}
```
2. Add the LimeSurvey xblock as a component of your course, you can use dummy values for the Studio configuration. The student view doesn't really matter for these tests.
3. Go to the instructor dashboard with the proper permissions (as an instructor of the course). You'll see:
![Screenshot from 2023-06-13 16-21-22](https://github.com/openedx/openedx-filters/assets/64440265/71bad89f-314e-44ff-895e-ef85d66cd1d5)

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)