### PR TITLE
[POC] feat: add filters for roles management (1st approach)

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -662,3 +662,35 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
+
+
+class AccessRoleCheckRequested(OpenEdxPublicFilter):
+
+    @classmethod
+    def run_filter(cls, user, roles, course_key):
+        data = super().run_pipeline(user=user, roles=roles, course_key=course_key)
+        return data.get("user"), data.get("roles"), data.get("course_key")
+
+
+class AccessRoleAdditionRequested(OpenEdxPublicFilter):
+
+    @classmethod
+    def run_filter(cls, user, roles, course_key):
+        data = super().run_pipeline(user=user, roles=roles, course_key=course_key)
+        return data.get("user"), data.get("roles"), data.get("course_key")
+
+
+class AccessRoleRemovalRequested(OpenEdxPublicFilter):
+
+    @classmethod
+    def run_filter(cls, user, roles, course_key):
+        data = super().run_pipeline(user=user, roles=roles, course_key=course_key)
+        return data.get("user"), data.get("roles"), data.get("course_key")
+
+
+class UsersWithRolesRequested(OpenEdxPublicFilter):
+
+    @classmethod
+    def run_filter(cls, user, roles, course_key):
+        data = super().run_pipeline(user=user, roles=roles, course_key=course_key)
+        return data.get("user"), data.get("roles"), data.get("course_key")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -666,6 +666,8 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 
 class AccessRoleCheckRequested(OpenEdxPublicFilter):
 
+    filter_type = "org.openedx.learning.access.role.check.requested.v1"
+
     @classmethod
     def run_filter(cls, user, roles, course_key):
         data = super().run_pipeline(user=user, roles=roles, course_key=course_key)
@@ -673,6 +675,8 @@ class AccessRoleCheckRequested(OpenEdxPublicFilter):
 
 
 class AccessRoleAdditionRequested(OpenEdxPublicFilter):
+
+    filter_type = "org.openedx.learning.access.role.addition.requested.v1"
 
     @classmethod
     def run_filter(cls, user, roles, course_key):
@@ -682,6 +686,8 @@ class AccessRoleAdditionRequested(OpenEdxPublicFilter):
 
 class AccessRoleRemovalRequested(OpenEdxPublicFilter):
 
+    filter_type = "org.openedx.learning.access.role.removal.requested.v1"
+
     @classmethod
     def run_filter(cls, user, roles, course_key):
         data = super().run_pipeline(user=user, roles=roles, course_key=course_key)
@@ -689,6 +695,8 @@ class AccessRoleRemovalRequested(OpenEdxPublicFilter):
 
 
 class UsersWithRolesRequested(OpenEdxPublicFilter):
+
+    filter_type = "org.openedx.learning.access.role.users.retrieval.requested.v1"
 
     @classmethod
     def run_filter(cls, user, roles, course_key):


### PR DESCRIPTION
### Description
This PR adds filters aimed to be used for roles management in the main openedx services. Here's is an example of how they can be used: 

They might be triggered by:
https://github.com/openedx/edx-platform/compare/master...MJG/roles-refactor-by-filters

And with the following pipeline steps, we can add an additional role implemented in a plugin:
https://github.com/mariajgrimaldi/platform-plugin-sample/commit/13a20ac6b4a60b2773734187dd7c8937228a167a

Configured using this Django setting:
```
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.instructor.dashboard.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "platform_plugin_sample.extensions.filters.CheckProfessorRole",
        ]
    },
```