### PR TITLE
feat: added filter for modifying the isStarted for externally hosted …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ----------
 
+[1.5.0] - 2023-07-19
+--------------------
+
+Added
+~~~~~
+
+* CourseEnrollmentAPIRenderStarted filter added which can be used to modify the isStarted B2C dashboard rendering process.
+
+
 [1.4.0] - 2023-07-18
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -591,6 +591,26 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
         return data.get("course_key"), data.get("course_home_url")
 
 
+class CourseEnrollmentAPIRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create filters for enrollment data.
+    """
+
+    filter_type = "org.openedx.learning.home.enrollment.api.rendered.v1"
+
+    @classmethod
+    def run_filter(cls, course_key, serialized_enrollment):
+        """
+        Execute a filter with the specified signature.
+
+        Arguments:
+            course_key (CourseKey): The course key for which isStarted is being modify.
+            serialized_enrollment (dict): enrollment data
+        """
+        data = super().run_pipeline(course_key=course_key, serialized_enrollment=serialized_enrollment)
+        return data.get("course_key"), data.get("serialized_enrollment")
+
+
 class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
     """
     Custom class used to create instructor dashboard filters and its custom methods.

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -13,6 +13,7 @@ from openedx_filters.learning.filters import (
     CohortAssignmentRequested,
     CohortChangeRequested,
     CourseAboutRenderStarted,
+    CourseEnrollmentAPIRenderStarted,
     CourseEnrollmentQuerysetRequested,
     CourseEnrollmentStarted,
     CourseHomeUrlCreationStarted,
@@ -604,3 +605,17 @@ class TestFederatedContentFilters(TestCase):
         result = CourseHomeUrlCreationStarted.run_filter(course_key, course_home_url)
 
         self.assertTupleEqual((course_key, course_home_url,), result)
+
+    def test_course_enrollment_api_render_started(self):
+        """
+        Test CourseEnrollmentAPIRenderStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return course_key and is_started in that order.
+        """
+        course_key, serialized_enrollment = Mock(), Mock()
+
+        result = CourseEnrollmentAPIRenderStarted.run_filter(course_key, serialized_enrollment)
+
+        self.assertTupleEqual((course_key, serialized_enrollment,), result)


### PR DESCRIPTION
**Description**: 
This PR adds a filter for modifying the `isStarted` for externally hosted courses. This hook will identify whether the learner has started the course or not.

**Reference**: 
Actually, this field will be used to identify whether the learner has started the course or not. And we will conditionally render some things on the learner dashboard (B2C side) as described in [ENT-7188](https://2u-internal.atlassian.net/browse/ENT-7188).

**JIRA**- [ENT-7373](https://2u-internal.atlassian.net/browse/ENT-7373) and [ENT-at 7374](https://2u-internal.atlassian.net/browse/ENT-7374)


**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
