### PR TITLE
[WIP] feat: add ORA filter for student_view rendering intervention

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -662,3 +662,61 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
+
+
+class ORAStudentViewRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create dashboard render filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.ora.student_view.render.started.v1"
+
+    class RenderInvalidTemplate(OpenEdxFilterException):
+        """
+        Custom class used to stop the dashboard render process.
+        """
+
+        def __init__(self, message, dashboard_template="", template_context=None):
+            """
+            Override init that defines specific arguments used in the dashboard render process.
+
+            Arguments:
+                message: error message for the exception.
+                dashboard_template: template path rendered instead.
+                template_context: context used to the new dashboard_template.
+            """
+            super().__init__(
+                message,
+                dashboard_template=dashboard_template,
+                template_context=template_context,
+            )
+
+    class RenderCustomFragment(OpenEdxFilterException):
+        """
+        Custom class used to stop the dashboard rendering process.
+        """
+
+        def __init__(self, message, fragment=None):
+            """
+            Override init that defines specific arguments used in the dashboard render process.
+
+            Arguments:
+                message: error message for the exception.
+                response: custom response which will be returned by the dashboard view.
+            """
+            super().__init__(
+                message,
+                fragment=fragment,
+            )
+
+    @classmethod
+    def run_filter(cls, context, template_name):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for student's dashboard template.
+            template_name (str): template name to be rendered by the student's dashboard.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")


### PR DESCRIPTION
### Description
This PR adds a filter meant to be used before rendering the `student_view` for the [ORA Xblock](https://github.com/openedx/edx-ora2/). Here's a list of use cases we have in mind for this kind of filter:
- By accessing the block data from the template context -- data like the assessment response or files uploaded, we could check the assessment for plagiarism, correctness, etc with a 3rd party service
- We could also change prompts dynamically depending on a student's attribute
- By altering the context and the ORA template, we can change ORAs base design if we want to
The idea is to have access to the block status in a moment in time so we can externally access it.

The specific use case we're implementing with this filter is:

_As a professor or student, I want to check my essay with an external service like Turnitin for plagiarism._

This is how I imagine the use case implementation:
![image](https://github.com/openedx/openedx-filters/assets/64440265/f638ebf1-19af-4774-8b70-a3b6e206d72a)

### How to test
This is a proof of concept, so testing it can be wacky. Here's a list of steps you can follow so you can test the ongoing implementation:
1. Install the needed libraries:
```
pip install git+https://github.com/openedx/openedx-filters.git@MJG/ora-student-view-filter
pip install git+https://github.com/eduNEXT/edx-ora2.git@MJG/ora-student-view-filter
pip install git+https://github.com/eduNEXT/platform-plugin-turnitin.git@MJG/turnitin-pipeline-step
```
2. Add the following configuration:
```
    OPEN_EDX_FILTERS_CONFIG = {
      "org.openedx.learning.ora.student_view.render.started.v1": {
          "fail_silently": False,
          "pipeline": [
              "platform_plugin_turnitin.extensions.filters.CheckTurnitinForPlagiarism",
          ]
      },
    }
```
3. Restart services
4. Configure an ORA block for text submissions
5. Submit your assessment

### References
Turnitin: https://www.turnitin.com/
