### PR TITLE
fix: add tox 4.0 support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,11 +5,15 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: requirements/doc.txt

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -6,4 +6,3 @@
 -r ci.txt             # dependencies needed to setup testing environment on CI
 
 diff-cover                # Changeset diff test coverage
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -316,9 +316,6 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/dev.in
 twine==4.0.2
     # via -r requirements/quality.txt
 typing-extensions==4.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 setenv =
     DJANGO_SETTINGS_MODULE = test_utils.test_settings
     PYTHONPATH = {toxinidir}
-whitelist_externals =
+allowlist_externals =
     make
     rm
 deps =
@@ -60,7 +60,7 @@ commands =
     python setup.py check --restructuredtext --strict
 
 [testenv:quality]
-whitelist_externals =
+allowlist_externals =
     make
     rm
     touch


### PR DESCRIPTION
## Description
- Updated tox config to add tox 4.0 support
- Removed usage of tox-battery from requirements
- Updated `.readthedocs.yml` config file to fix the failing docs build check.