### PR TITLE
feat: add ORA filter for submission view rendering intervention

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+[1.8.0] - 2024-04-11
+
+Added
+~~~~~
+
+* ORASubmissionViewRenderStarted filter added which can be used to modify the ORA submission view.
+
 [1.7.0] - 2024-04-11
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -2,6 +2,8 @@
 Package where filters related to the learning architectural subdomain are implemented.
 """
 
+from typing import Optional
+
 from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.tooling import OpenEdxPublicFilter
 from openedx_filters.utils import SensitiveDataManagementMixin
@@ -700,4 +702,40 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
             template_name (str): template name to be rendered by the instructor's tab.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")
+
+
+class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create ORA submission view filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.ora.submission_view.render.started.v1"
+
+    class RenderInvalidTemplate(OpenEdxFilterException):
+        """
+        Custom class used to stop the submission view render process.
+        """
+
+        def __init__(self, message: str, context: Optional[dict] = None, template_name: str = ""):
+            """
+            Override init that defines specific arguments used in the submission view render process.
+
+            Arguments:
+                message (str): error message for the exception.
+                context (dict): context used to the submission view template.
+                template_name (str): template path rendered instead.
+            """
+            super().__init__(message, context=context, template_name=template_name)
+
+    @classmethod
+    def run_filter(cls, context: dict, template_name: str):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for submission view template.
+            template_name (str): template name to be rendered by the student's dashboard.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name, )
         return data.get("context"), data.get("template_name")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -21,6 +21,7 @@ from openedx_filters.learning.filters import (
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
     InstructorDashboardRenderStarted,
+    ORASubmissionViewRenderStarted,
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
@@ -543,6 +544,36 @@ class TestRenderingFilters(TestCase):
             - The exception must have the attributes specified.
         """
         exception = dashboard_exception(message="You can't access the dashboard", **attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    def test_ora_submission_view_render_started(self):
+        """
+        Test ORASubmissionViewRenderStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return context and template_name in that order.
+        """
+        result = ORASubmissionViewRenderStarted.run_filter(self.context, self.template_name)
+
+        self.assertTupleEqual((self.context, self.template_name,), result)
+
+    @data(
+        (
+            ORASubmissionViewRenderStarted.RenderInvalidTemplate,
+            {"context": {"course": Mock()}, "template_name": "custom-template.html"},
+        ),
+    )
+    @unpack
+    def test_halt_ora_submission_view_render(self, dashboard_exception, attributes):
+        """
+        Test for the ora submission view exceptions attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = dashboard_exception(message="You can't access the view", **attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
 


### PR DESCRIPTION
## Description
This PR adds a filter to modify the default template of submissions in an ORA assignment.

- New filter: `ORASubmissionViewRenderStarted`
- New exception: `RenderInvalidTemplate` 

## Supporting Information
These changes are based on those proposed in the [following ADR](https://github.com/openedx/edx-ora2/pull/2182)