### PR TITLE
feat: add filter for hooking XBlock Render

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[1.9.0] - 2024-06-14
+--------------------
+
+Added
+~~~~~~~
+
+* RenderXBlockStarted filter added which allows reading / modifying of XBlock context prior to render.
+
 [1.8.1] - 2024-04-12
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.8.1"
+__version__ = "1.9.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -546,6 +546,46 @@ class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
         return data.get("enrollments")
 
 
+class RenderXBlockStarted(OpenEdxPublicFilter):
+    """
+    Filter in between context generation and rendering of XBlock scope.
+    """
+
+    filter_type = "org.openedx.learning.xblock.render.started.v1"
+
+    class PreventXBlockBlockRender(OpenEdxFilterException):
+        """
+        Custom class used to prevent the XBlock from rendering for the user.
+        """
+
+    class RenderCustomResponse(OpenEdxFilterException):
+        """
+        Custom class used to stop the XBlock rendering process and return a custom response.
+        """
+
+        def __init__(self, message, response=None):
+            """
+            Override init that defines specific arguments used in the XBlock render process.
+
+            Arguments:
+                message: error message for the exception.
+                response: custom response which will be returned by the XBlock render view.
+            """
+            super().__init__(message, response=response)
+
+    @classmethod
+    def run_filter(cls, context, student_view_context):
+        """
+        Execute a filter with the specified signature.
+
+        Arguments:
+            context (dict): rendering context values like is_mobile_app, show_title, etc.
+            student_view_context (dict): context passed to the student_view of the block context
+        """
+        data = super().run_pipeline(context=context, student_view_context=student_view_context)
+        return data.get("context"), data.get("student_view_context")
+
+
 class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
     """
     Custom class used to create filters to act on vertical block rendering completed.

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -22,6 +22,7 @@ from openedx_filters.learning.filters import (
     DashboardRenderStarted,
     InstructorDashboardRenderStarted,
     ORASubmissionViewRenderStarted,
+    RenderXBlockStarted,
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
@@ -476,6 +477,68 @@ class TestRenderingFilters(TestCase):
             - The exception must have the attributes specified.
         """
         exception = render_exception(**attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    def test_xblock_render_started(self):
+        """
+        Test RenderXBlockStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return the expected values
+        """
+        context = {
+            "foo": False,
+            "bar": "baz",
+            "buzz": 1337,
+        }
+        student_view_context = {
+            "arbitrary_context": "value",
+            "more_arbitrary_context": True
+        }
+
+        result = VerticalBlockChildRenderStarted.run_filter(context, student_view_context)
+
+        self.assertTupleEqual((context, student_view_context), result)
+
+    @data(
+        (
+            RenderXBlockStarted.PreventXBlockBlockRender,
+            {
+                "message": "Danger, Will Robinson!"
+            }
+        )
+    )
+    @unpack
+    def test_halt_xblock_render(self, xblock_render_exception, attributes):
+        """
+        Test for xblock render exception attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = xblock_render_exception(**attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)
+
+    @data(
+        (
+            RenderXBlockStarted.RenderCustomResponse,
+            {
+                "message": "Danger, Will Robinson!"
+            }
+        )
+    )
+    @unpack
+    def test_halt_xblock_render_custom_response(self, xblock_render_exception, attributes):
+        """
+        Test for xblock render exception attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = xblock_render_exception(**attributes)
 
         self.assertDictContainsSubset(attributes, exception.__dict__)
 


### PR DESCRIPTION
**Description:** Add a filter just before rendering of an XBlock scope. [See discussion forum](https://discuss.openedx.org/t/filter-in-xblock-render-pipeline/13095/5).

**Justification:** Some of our current work requires an ability to read and modify data in the XBlock render pipeline. While there *already* exist filters in the Vertical rendering pipeline, these are limited compared to the XBlock rendering pipeline in 2 important ways.

1. The vertical render does not have access to the original request object, meaning if we are otherwise unable to read/modify data on or in response to that request.
2. The vertical render pipeline does not apply to XBlock scopes outside of vertical/unit. If, for example, we ask to render an individual block, these filters will not get activated.

**JIRA:** [AU-2039](https://2u-internal.atlassian.net/browse/AU-2039) and [2037](https://2u-internal.atlassian.net/browse/AU-2037)

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** n/a

**Testing instructions:**

1. Check out related edx-platform branch: [nsprenkle/xblock-render-filter](https://github.com/openedx/edx-platform/tree/nsprenkle/xblock-render-filter)
4. Install local copy of `openedx-filters`.
5. Attempt to render an xblobk: `http://{lms}/xblock/block-v1:{block-id}?view=student_view`
6. Verify filter step is run.

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [x] All reviewers approved
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
