### PR TITLE
docs: add configuration for automatic filters docs generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ----------
+* Configuration for automatic filters docs generation.
 
 [1.8.1] - 2024-04-12
 --------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
@@ -35,6 +34,8 @@ extensions = [
     'sphinx_copybutton',
     'sphinx.ext.graphviz',
     'sphinxcontrib.mermaid',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/reference/filters.rst
+++ b/docs/reference/filters.rst
@@ -1,0 +1,10 @@
+Filters
+=======
+
+This is the list of Open edX Filters found in this repository.
+
+.. note::
+    Filters can be created in other projects and plugins as well, but these default filters are guaranteed to exist.
+
+.. automodule:: openedx_filters.learning.filters
+   :members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -5,5 +5,5 @@ References
    :maxdepth: 1
    :caption: Contents:
 
-   django-plugins-and-filters
    filters
+   django-plugins-and-filters

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,3 +6,4 @@ References
    :caption: Contents:
 
    django-plugins-and-filters
+   filters


### PR DESCRIPTION
### Description
This PR adds the necessary configuration for automatic docs generation based on Open edX Filters classes, you can see the docs generated here: https://docsopenedxorg--173.org.readthedocs.build/projects/openedx-filters/en/173/