### PR TITLE
feat: adds CourseAboutPageURLRequested and LMSPageURLRequested filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,15 @@ Unreleased
 ----------
 * Configuration for automatic filters docs generation.
 
+[1.11.0] - 2024-09-30
+--------------------
+
+Added
+~~~~~
+
+* CourseAboutPageURLRequested filter added which can be used to modify the URL for the course about organization.
+* LMSPageURLRequested filter added which can be used to modify the URL for the LMS page organization.
+
 [1.10.0] - 2024-09-20
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,16 +16,16 @@ Unreleased
 * Configuration for automatic filters docs generation.
 
 [1.11.0] - 2024-09-30
---------------------
+---------------------
 
 Added
 ~~~~~
 
-* CourseAboutPageURLRequested filter added which can be used to modify the URL for the course about organization.
-* LMSPageURLRequested filter added which can be used to modify the URL for the LMS page organization.
+* CourseAboutPageURLRequested filter added which can be used to modify the URL for the course about page.
+* LMSPageURLRequested filter added which can be used to modify the URL for the LMS page.
 
 [1.10.0] - 2024-09-20
---------------------
+---------------------
 
 Added
 ~~~~~

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/openedx_filters/course_authoring/__init__.py
+++ b/openedx_filters/course_authoring/__init__.py
@@ -1,0 +1,6 @@
+"""
+Package where events related to the ``content_authoring`` subdomain are implemented.
+
+The ``content_authoring`` subdomain corresponds to {Architecture Subdomain} defined in OEP-41.
+https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0041-arch-async-server-event-messaging.html
+"""

--- a/openedx_filters/course_authoring/filters.py
+++ b/openedx_filters/course_authoring/filters.py
@@ -1,0 +1,25 @@
+"""
+Package where filters related to the Course Authoring architectural subdomain are implemented.
+"""
+
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class LMSPageURLRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to get lms page url filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.course_authoring.lms.page.url.requested.v1"
+
+    @classmethod
+    def run_filter(cls, url, org):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            url (str): the URL of the page to be modified.
+            org (str): Course org filter used as context data to get LMS configurations.
+        """
+        data = super().run_pipeline(url=url, org=org)
+        return data.get("url"), data.get("org")

--- a/openedx_filters/course_authoring/tests/__init__.py
+++ b/openedx_filters/course_authoring/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Package where unittest for authoring subdomain filters are located.
+"""

--- a/openedx_filters/course_authoring/tests/test_filters.py
+++ b/openedx_filters/course_authoring/tests/test_filters.py
@@ -1,0 +1,32 @@
+"""
+Tests for authoring subdomain filters.
+"""
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from openedx_filters.course_authoring.filters import LMSPageURLRequested
+
+
+class TestCourseAuthoringFilters(TestCase):
+    """
+    Test class to verify standard behavior of the filters located in rendering views.
+    You'll find test suites for:
+
+    - LMSPageURLRequested
+    """
+
+    def test_lms_page_url_requested(self):
+        """
+        Test LMSPageURLRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return lms page url requested.
+        """
+        url = Mock()
+        org = Mock()
+
+        url_result, org_result = LMSPageURLRequested.run_filter(url, org)
+
+        self.assertEqual(url, url_result)
+        self.assertEqual(org, org_result)

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -798,3 +798,23 @@ class IDVPageURLRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(url=url)
         return data.get("url")
+
+
+class CourseAboutPageURLRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to get course about page url filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.course_about.page.url.requested.v1"
+
+    @classmethod
+    def run_filter(cls, url, org):
+        """
+        Execute a filter with the specified signature.
+
+        Arguments:
+            url (str): the URL of the page to be modified.
+            org (str): Course org filter used as context data to get LMS configurations.
+        """
+        data = super().run_pipeline(url=url, org=org)
+        return data.get("url"), data.get("org")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -12,6 +12,7 @@ from openedx_filters.learning.filters import (
     CertificateRenderStarted,
     CohortAssignmentRequested,
     CohortChangeRequested,
+    CourseAboutPageURLRequested,
     CourseAboutRenderStarted,
     CourseEnrollmentAPIRenderStarted,
     CourseEnrollmentQuerysetRequested,
@@ -752,3 +753,26 @@ class TestIDVFilters(TestCase):
         result = IDVPageURLRequested.run_filter(url)
 
         self.assertEqual(url, result)
+
+
+class TestCourseAboutPageURLRequested(TestCase):
+    """
+    Test class to verify standard behavior of the ID verification filters.
+    You'll find test suites for:
+
+    - CourseAboutPageURLRequested
+    """
+
+    def test_lms_page_url_requested(self):
+        """
+        Test CourseAboutPageURLRequested filter behavior under normal conditions.
+        Expected behavior:
+            - The filter should return lms page url requested.
+        """
+        url = Mock()
+        org = Mock()
+
+        url_result, org_result = CourseAboutPageURLRequested.run_filter(url, org)
+
+        self.assertEqual(url, url_result)
+        self.assertEqual(org, org_result)


### PR DESCRIPTION
**Description:** Describe in a couple of sentences what this PR adds

This adds the TenantAwareLinkRenderStarted filter which receive a string context with LMS url to allowing the filter pipeline to return the information that we need to filter, in this case a tenant aware link from Studio to LMS.

An example of use is in [eox-tenant](https://github.com/eduNEXT/eox-tenant) custom filter step [pipeline](https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/filters/pipeline.py), where it takes the LMS_ROOT_URL and return only the tenant aware link in the respective site.

**JIRA:** [DS-1003](https://edunext.atlassian.net/browse/DS-1003)

**Dependencies:** 

https://github.com/openedx/edx-platform/pull/35142

**Merge deadline:** N/A

**Installation instructions:** 

Be sure to use edx-platform branch with changes https://github.com/openedx/edx-platform/pull/35142

**Testing instructions:**

The change can be tested with testing instructions in https://github.com/eduNEXT/eox-tenant/pull/156.

**Reviewers:**
- [ ] @mariajgrimaldi 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
N/A
