### PR TITLE
feat: Implement IDV URL Filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ Unreleased
 ----------
 * Configuration for automatic filters docs generation.
 
+[1.10.0] - 2024-09-20
+--------------------
+
+Added
+~~~~~
+
+* IDVPageURLRequested filter added which can be used to modify the URL for the ID verification process.
+
 [1.9.0] - 2024-06-14
 --------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -779,3 +779,22 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, template_name=template_name, )
         return data.get("context"), data.get("template_name")
+
+
+class IDVPageURLRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to create filters to act on ID verification page URL requests.
+    """
+
+    filter_type = "org.openedx.learning.idv.page.url.requested.v1"
+
+    @classmethod
+    def run_filter(cls, url):
+        """
+        Execute a filter with the specified signature.
+
+        Arguments:
+            url (str): The url for the ID verification page to be modified.
+        """
+        data = super().run_pipeline(url=url)
+        return data.get("url")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -789,7 +789,7 @@ class IDVPageURLRequested(OpenEdxPublicFilter):
     filter_type = "org.openedx.learning.idv.page.url.requested.v1"
 
     @classmethod
-    def run_filter(cls, url):
+    def run_filter(cls, url: str):
         """
         Execute a filter with the specified signature.
 

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -751,4 +751,4 @@ class TestIDVFilters(TestCase):
 
         result = IDVPageURLRequested.run_filter(url)
 
-        self.assertEquals(url, result)
+        self.assertEqual(url, result)

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -20,6 +20,7 @@ from openedx_filters.learning.filters import (
     CourseRunAPIRenderStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
+    IDVPageURLRequested,
     InstructorDashboardRenderStarted,
     ORASubmissionViewRenderStarted,
     RenderXBlockStarted,
@@ -728,3 +729,26 @@ class TestFederatedContentFilters(TestCase):
         result = CourseRunAPIRenderStarted.run_filter(serialized_courserun)
 
         self.assertEqual(serialized_courserun, result)
+
+
+class TestIDVFilters(TestCase):
+    """
+    Test class to verify standard behavior of the ID verification filters.
+    You'll find test suites for:
+
+    - IDVPageURLRequested
+    """
+
+    def test_course_idv_page_url_requested(self):
+        """
+        Test IDVPageURLRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return the url.
+        """
+        url = Mock(), Mock()
+
+        result = IDVPageURLRequested.run_filter(url)
+
+        self.assertEquals(url, result)

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -739,7 +739,7 @@ class TestIDVFilters(TestCase):
     - IDVPageURLRequested
     """
 
-    def test_course_idv_page_url_requested(self):
+    def test_idv_page_url_requested(self):
         """
         Test IDVPageURLRequested filter behavior under normal conditions.
 
@@ -747,7 +747,7 @@ class TestIDVFilters(TestCase):
             - The filter must have the signature specified.
             - The filter should return the url.
         """
-        url = Mock(), Mock()
+        url = Mock()
 
         result = IDVPageURLRequested.run_filter(url)
 


### PR DESCRIPTION
**Description:** The purpose of this PR is to add an Open edX filter hook for getting the URL to the IDV page to the [GitHub - openedx/openedx-filters: Open edX filters from the Hooks Extensions Framework](https://github.com/openedx/openedx-filters)  repository.

For the sake of justifying this filter, here is the relevant [Open edX Product Proposal](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4307386369/Proposal+Add+Extensibility+Mechanisms+to+IDV+to+Enable+Integration+of+New+IDV+Vendor+Persona) and [Issue](https://github.com/openedx/platform-roadmap/issues/367) to `Add Extensibility Mechanisms to IDV to Enable Integration of New IDV Vendor Persona`.

**JIRA:** [Link to JIRA ticket
](https://2u-internal.atlassian.net/browse/COSMO-423)

**Dependencies:** None

**Merge deadline:** N/A

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)