### PR TITLE
build: run workflows exclusively with ubuntu-latest and py11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python-version: ['3.8', '3.11']
+        os: [ubuntu-latest]
+        python-version: ['3.11']
         toxenv: ["django42", "quality", "docs"]
 
     steps:
@@ -37,7 +37,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django42'
       uses: codecov/codecov-action@v4
       with:
         flags: unittests

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# Temporary to Support the python 3.11 Upgrade
-backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=load_requirements("requirements/base.in"),
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     license="AGPL 3.0",
     zip_safe=False,
     keywords="Python openedx",
@@ -157,7 +157,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38, 311}-django{42}, quality, docs
+envlist = py{311}-django{42}, quality, docs
 
 
 [doc8]


### PR DESCRIPTION
### Description
Addresses https://github.com/openedx/openedx-filters/issues/206 by dropping ubuntu-20.04 and partially addresses by dropping py3.8 https://github.com/openedx/openedx-filters/issues/212 in workflows