### PR TITLE
feat: add schedule queryset requested filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Unreleased
 * Configuration for automatic filters docs generation.
 
 
-[1.12.0] - 2024-12-10
+[1.12.0] - 2024-12-12
 ---------------------
 
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,15 @@ Unreleased
 ----------
 * Configuration for automatic filters docs generation.
 
+
+[1.12.0] - 2024-12-10
+---------------------
+
+Added
+~~~~~
+
+* ScheduleQuerySetRequested filter added which can be used to modify the Schedule QuerySet.
+
 [1.11.0] - 2024-09-30
 ---------------------
 

--- a/docs/reference/real-life-use-cases.rst
+++ b/docs/reference/real-life-use-cases.rst
@@ -73,6 +73,13 @@ Webfilters, as mentioned in `openedx-webhooks`_ is a type of webhook that allows
 
 More details on `Open edX Webhooks - Webfilters`_.
 
+Schedules Filtering
+*******************
+
+When a automatic email message is scheduled to be sent to students, a filter is executed to modify the schedule. This functionality allows you to define specific criteria to determine which students will receive the email. For example, filters can check whether students have opted to receive newsletters, assess their progress in the course, evaluate their activity, or consider other relevant conditions.
+
+More details on `Schedule Filtering`_.
+
 Other Use Cases
 ***************
 
@@ -106,3 +113,4 @@ Here are some additional use cases that can be implemented using Open edX Filter
 .. _IDV Integration with new Vendors: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4307386369/Proposal+Add+Extensibility+Mechanisms+to+IDV+to+Enable+Integration+of+New+IDV+Vendor+Persona
 .. _Render Alternative Course About: https://github.com/lektorium-tutor/lektorium_main/blob/master/lektorium_main/tilda/pipeline.py#L15-L94
 .. _Hide Course About from Users Without Memberships: https://github.com/academic-innovation/mogc-partnerships/blob/main/mogc_partnerships/pipeline.py#L53-L66
+.. _Schedule Filtering: https://github.com/fccn/nau-openedx-extensions/pull/56

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -825,6 +825,10 @@ class CourseAboutPageURLRequested(OpenEdxPublicFilter):
 class ScheduleQuerySetRequested(OpenEdxPublicFilter):
     """
     Filter class designed to apply additional filtering to a given QuerySet of Schedules.
+
+    If you want to know more about the Schedules feature, please refer:
+    - https://github.com/openedx/edx-platform/tree/master/openedx/core/djangoapps/schedules#readme
+    - https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/manage_live_course/automatic_email.html
     """
 
     filter_type = "org.openedx.learning.schedule.queryset.requested.v1"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -829,25 +829,6 @@ class ScheduleQuerySetRequested(OpenEdxPublicFilter):
 
     filter_type = "org.openedx.learning.schedule.queryset.requested.v1"
 
-    class PreventScheduleQuerySetRequest(OpenEdxFilterException):
-        """
-        Custom exception to halt the schedule QuerySet request process.
-
-        This exception is raised when the filtering process encounters a condition
-        that prevents further processing of the QuerySet. It returns the original
-        QuerySet.
-        """
-
-        def __init__(self, message: str, schedules: QuerySet):
-            """
-            Initialize the PreventScheduleQuerySetRequest with a message and a QuerySet.
-
-            Arguments:
-                message (str): A descriptive error message for the exception.
-                schedules (QuerySet): The QuerySet of schedules causing the exception.
-            """
-            super().__init__(message, schedules=schedules)
-
     @classmethod
     def run_filter(cls, schedules: QuerySet) -> QuerySet:
         """

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -824,36 +824,44 @@ class CourseAboutPageURLRequested(OpenEdxPublicFilter):
 
 class ScheduleQuerySetRequested(OpenEdxPublicFilter):
     """
-    Custom class used to create schedule queryset filters filters and its custom methods.
+    Filter class designed to apply additional filtering to a given QuerySet of Schedules.
     """
 
     filter_type = "org.openedx.learning.schedule.queryset.requested.v1"
 
     class PreventScheduleQuerySetRequest(OpenEdxFilterException):
         """
-        Custom class used to stop the schedule queryset request process.
+        Custom exception to halt the schedule QuerySet request process.
+
+        This exception is raised when the filtering process encounters a condition
+        that prevents further processing of the QuerySet. It returns the original
+        QuerySet.
         """
 
         def __init__(self, message: str, schedules: QuerySet):
             """
-            Override init that defines specific arguments used in the schedule queryset request process.
+            Initialize the PreventScheduleQuerySetRequest with a message and a QuerySet.
 
             Arguments:
-                message (str): error message for the exception.
-                schedules (QuerySet): Queryset of schedules to be sent
+                message (str): A descriptive error message for the exception.
+                schedules (QuerySet): The QuerySet of schedules causing the exception.
             """
             super().__init__(message, schedules=schedules)
 
     @classmethod
     def run_filter(cls, schedules: QuerySet) -> QuerySet:
         """
-        Execute a filter with the signature specified.
+        Execute the filtering logic for the given QuerySet of schedules.
+
+        This method processes the input QuerySet using the configured pipeline steps
+        to applies additional filtering rules. It returns the filtered QuerySet for
+        further processing.
 
         Arguments:
-            schedules (QuerySet): Queryset of schedules to be sent.
+            schedules (QuerySet): The original QuerySet of schedules to be filtered.
 
         Returns:
-            QuerySet: Schedules to be sent.
+            QuerySet: A refined QuerySet of schedules after applying the filter.
         """
         data = super().run_pipeline(schedules=schedules)
         return data.get("schedules")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -4,6 +4,8 @@ Package where filters related to the learning architectural subdomain are implem
 
 from typing import Optional
 
+from django.db.models.query import QuerySet
+
 from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.tooling import OpenEdxPublicFilter
 from openedx_filters.utils import SensitiveDataManagementMixin
@@ -818,3 +820,40 @@ class CourseAboutPageURLRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(url=url, org=org)
         return data.get("url"), data.get("org")
+
+
+class ScheduleQuerySetRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to create schedule queryset filters filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.schedule.queryset.requested.v1"
+
+    class PreventScheduleQuerySetRequest(OpenEdxFilterException):
+        """
+        Custom class used to stop the schedule queryset request process.
+        """
+
+        def __init__(self, message: str, schedules: QuerySet):
+            """
+            Override init that defines specific arguments used in the schedule queryset request process.
+
+            Arguments:
+                message (str): error message for the exception.
+                schedules (QuerySet): Queryset of schedules to be sent
+            """
+            super().__init__(message, schedules=schedules)
+
+    @classmethod
+    def run_filter(cls, schedules: QuerySet) -> QuerySet:
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            schedules (QuerySet): Queryset of schedules to be sent.
+
+        Returns:
+            QuerySet: Schedules to be sent.
+        """
+        data = super().run_pipeline(schedules=schedules)
+        return data.get("schedules")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -25,6 +25,7 @@ from openedx_filters.learning.filters import (
     InstructorDashboardRenderStarted,
     ORASubmissionViewRenderStarted,
     RenderXBlockStarted,
+    ScheduleQuerySetRequested,
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
@@ -776,3 +777,44 @@ class TestCourseAboutPageURLRequested(TestCase):
 
         self.assertEqual(url, url_result)
         self.assertEqual(org, org_result)
+
+
+@ddt
+class TestScheduleFilters(TestCase):
+    """
+    Test class to verify standard behavior of the schedule filters.
+
+    You'll find test suites for:
+    - `ScheduleQuerySetRequested`
+    """
+
+    def test_schedule_requested(self):
+        """
+        Test schedule requested filter.
+
+        Expected behavior:
+            - The filter should return the filterd schedules.
+        """
+        schedules = Mock()
+
+        result = ScheduleQuerySetRequested.run_filter(schedules)
+
+        self.assertEqual(schedules, result)
+
+    @data(
+        (
+            ScheduleQuerySetRequested.PreventScheduleQuerySetRequest,
+            {"schedules":  Mock(), "message": "Can't request QuerySet Schedule."}
+        )
+    )
+    @unpack
+    def test_halt_queryset_request(self, request_exception, attributes):
+        """
+        Test for queryset request exceptions attributes.
+
+        Expected behavior:
+            - The exception must have the attributes specified.
+        """
+        exception = request_exception(**attributes)
+
+        self.assertDictContainsSubset(attributes, exception.__dict__)

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -793,28 +793,10 @@ class TestScheduleFilters(TestCase):
         Test schedule requested filter.
 
         Expected behavior:
-            - The filter should return the filterd schedules.
+            - The filter should return the filtered schedules.
         """
         schedules = Mock()
 
         result = ScheduleQuerySetRequested.run_filter(schedules)
 
         self.assertEqual(schedules, result)
-
-    @data(
-        (
-            ScheduleQuerySetRequested.PreventScheduleQuerySetRequest,
-            {"schedules":  Mock(), "message": "Can't request QuerySet Schedule."}
-        )
-    )
-    @unpack
-    def test_halt_queryset_request(self, request_exception, attributes):
-        """
-        Test for queryset request exceptions attributes.
-
-        Expected behavior:
-            - The exception must have the attributes specified.
-        """
-        exception = request_exception(**attributes)
-
-        self.assertDictContainsSubset(attributes, exception.__dict__)


### PR DESCRIPTION
**Description:** This PR adds a filter to modify the default schedule queryset of the [automatic email messages](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/manage_live_course/automatic_email.html) in `edx-platform`.

The filter receives a single `schedules` argument of type `QuerySet`. An example of use is in this [NAU pipeline](https://github.com/fccn/nau-openedx-extensions/pull/56) that allows filtering the Schedules to only send emails to users who have the option to receive emails enabled in their profile (`allow_newsletter=True`)

**JIRA:** N/A

**Dependencies:**
- https://github.com/openedx/edx-platform/pull/35982

**Merge deadline:** NO

**Installation instructions:**
1. Create a Tutor environment.
2. Install this plugin with the changes in this PR. :warning: Don't forget to run migrations.
3. Install `openedx-filters` with the changes in [this PR](https://github.com/openedx/openedx-filters/pull/235).
4. Create a mount of `edx-platform` with the changes in [this PR](https://github.com/openedx/edx-platform/pull/35982). Please use the changes in [this branch](https://github.com/eduNEXT/edx-platform/tree/bav/schedule-queryset-filter-integration-debugging) _(For testing purposes)_.

**Testing instructions:**:
1. Create a new Schedule config for your site in `{lms_domain}/admin/schedules/scheduleconfig/`
   
    ![image](https://github.com/user-attachments/assets/22fa9c02-c334-46eb-9f82-e794c48ec684)
2. Create some users and enroll them in a course.
3. Create an NAU user extended model for each user in `{lms_domain}/admin/nau_openedx_extensions/nauuserextendedmodel/`. Update the following field, depending on whether you want to receive the newsletter.

    ![image](https://github.com/user-attachments/assets/13edefc4-f661-472c-884f-b1fa73978b66)

4. Create a Tutor inline plugin with the filter configuration:

    ```yml
    name: filter-settings
    version: 0.1.0
    patches:
      openedx-common-settings: |
        OPEN_EDX_FILTERS_CONFIG = {
          "org.openedx.learning.schedule.queryset.requested.v1": {
            "fail_silently": False,
            "pipeline": [
              "nau_openedx_extensions.filters.pipeline.FilterUsersWithAllowedNewsletter",
            ],
          },
        }
    ```
5. Send a message of recurring nudge using the following command in the LMS container:

    ```bash
    python manage.py lms send_recurring_nudge {site} --date {enroll-date + 3 days}
   # Example
    python manage.py lms send_recurring_nudge local.edly.io:8000 --date 2024-12-07
    ```
6. Depending on the value of each user's `allow_newsletter` field, you should see the filtered QuerySet of `Schedules` in the console. For example, here the Schedule was filtered because the user does not have the field set to **True**

    ![image](https://github.com/user-attachments/assets/85e9b6b3-a3c5-4ef5-ae46-ea1807a2d8d9)


**Reviewers:**
- [ ] @mariajgrimaldi 
- [ ] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
