### PR TITLE
docs: [FC-0074] enrich docstrings following a template with more details

### DIFF
--- a/openedx_filters/course_authoring/filters.py
+++ b/openedx_filters/course_authoring/filters.py
@@ -18,7 +18,7 @@ class LMSPageURLRequested(OpenEdxPublicFilter):
     Trigger:
         - Repository: openedx/edx-platform
         - Path: cms/djangoapps/contentstore/asset_storage_handler.py
-        - Function: get_asset_json
+        - Function or Method: get_asset_json
     """
 
     filter_type = "org.openedx.course_authoring.lms.page.url.requested.v1"

--- a/openedx_filters/course_authoring/filters.py
+++ b/openedx_filters/course_authoring/filters.py
@@ -9,6 +9,9 @@ class LMSPageURLRequested(OpenEdxPublicFilter):
     """
     Filter used to modify the URL of the page requested by the user.
 
+    This filter is triggered when a user loads a page in Studio that references an LMS page, allowing the filter to
+    modify the URL of the page requested by the user.
+
     Filter Type:
         org.openedx.course_authoring.lms.page.url.requested.v1
 
@@ -23,8 +26,7 @@ class LMSPageURLRequested(OpenEdxPublicFilter):
     @classmethod
     def run_filter(cls, url: str, org: str) -> tuple[str, str]:
         """
-        Process the input url and org using the configured pipeline steps to modify the URL of the page requested by the
-        user.
+        Process the inputs using the configured pipeline steps to modify the URL of the page requested by the user.
 
         Arguments:
             url (str): the URL of the page to be modified.

--- a/openedx_filters/course_authoring/filters.py
+++ b/openedx_filters/course_authoring/filters.py
@@ -7,15 +7,24 @@ from openedx_filters.tooling import OpenEdxPublicFilter
 
 class LMSPageURLRequested(OpenEdxPublicFilter):
     """
-    Custom class used to get lms page url filters and its custom methods.
+    Filter used to modify the URL of the page requested by the user.
+
+    Filter Type:
+        org.openedx.course_authoring.lms.page.url.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: cms/djangoapps/contentstore/asset_storage_handler.py
+        - Function: get_asset_json
     """
 
     filter_type = "org.openedx.course_authoring.lms.page.url.requested.v1"
 
     @classmethod
-    def run_filter(cls, url, org):
+    def run_filter(cls, url: str, org: str) -> tuple[str, str]:
         """
-        Execute a filter with the signature specified.
+        Process the input url and org using the configured pipeline steps to modify the URL of the page requested by the
+        user.
 
         Arguments:
             url (str): the URL of the page to be modified.

--- a/openedx_filters/course_authoring/filters.py
+++ b/openedx_filters/course_authoring/filters.py
@@ -29,8 +29,13 @@ class LMSPageURLRequested(OpenEdxPublicFilter):
         Process the inputs using the configured pipeline steps to modify the URL of the page requested by the user.
 
         Arguments:
-            url (str): the URL of the page to be modified.
-            org (str): Course org filter used as context data to get LMS configurations.
+            - url (str): the URL of the page to be modified.
+            - org (str): Course org filter used as context data to get LMS configurations.
+
+        Returns:
+            tuple[str, str]:
+                - str: the modified URL of the page requested by the user.
+                - str: the course org.
         """
         data = super().run_pipeline(url=url, org=org)
         return data.get("url"), data.get("org")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -66,7 +66,7 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
         def __init__(
             self,
             message: str,
-            account_settings_template: Optional[str] = "",
+            account_settings_template: str = "",
             template_context: Optional[dict] = None
         ) -> None:
             """Initialize the exception with the message and the template path to render instead."""
@@ -193,8 +193,8 @@ class StudentLoginRequested(OpenEdxPublicFilter):
         def __init__(
             self,
             message: str,
-            redirect_to: Optional[str] = "",
-            error_code: Optional[str] = "",
+            redirect_to: str = "",
+            error_code: str = "",
             context: Optional[dict] = None
         ) -> None:
             """Initialize the exception with the message and the URL to redirect to."""
@@ -410,7 +410,7 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
             - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: Optional[str] = "") -> None:
+        def __init__(self, message: str, redirect_to: str = "") -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -426,7 +426,7 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template path of the new certificate.
         """
 
-        def __init__(self, message: str, template_name: Optional[str] = "") -> None:
+        def __init__(self, message: str, template_name: str = "") -> None:
             """Initialize the exception with the message and the template path to render instead."""
             super().__init__(message, template_name=template_name)
 
@@ -583,7 +583,7 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
             - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: Optional[str] = "") -> None:
+        def __init__(self, message: str, redirect_to: str = "") -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -603,7 +603,7 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
         def __init__(
             self,
             message: str,
-            course_about_template: Optional[str] = "",
+            course_about_template: str = "",
             template_context: Optional[dict] = None
         ) -> None:
             """Initialize the exception with the message and the template to render instead."""
@@ -682,7 +682,7 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
             - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: Optional[str] = "") -> None:
+        def __init__(self, message: str, redirect_to: str = "") -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -702,7 +702,7 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         def __init__(
             self,
             message: str,
-            dashboard_template: Optional[str] = "",
+            dashboard_template: str = "",
             template_context: Optional[dict] = None
         ) -> None:
             """Initialize the exception with the message and the template to render instead."""
@@ -1070,7 +1070,7 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
             - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: Optional[str] = ""):
+        def __init__(self, message: str, redirect_to: str = ""):
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -1090,7 +1090,7 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         def __init__(
             self,
             message: str,
-            instructor_template: Optional[str] = "",
+            instructor_template: str = "",
             template_context: Optional[dict] = None
         ):
             """Initialize the exception with the message and the template to render instead."""
@@ -1171,7 +1171,7 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
         def __init__(
             self, message: str,
             context: Optional[dict] = None,
-            template_name: Optional[str] = ""
+            template_name: str = ""
         ) -> None:
             """Initialize the exception with the message and the template to render instead."""
             super().__init__(message, context=context, template_name=template_name)

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1031,10 +1031,10 @@ class CourseRunAPIRenderStarted(OpenEdxPublicFilter):
         Process the serialized_courserun using the configured pipeline steps to modify the course run data.
 
         Arguments:
-            serialized_courserun (dict): courserun data.
+            - serialized_courserun (dict): courserun data.
 
         Returns:
-            dict: courserun data.
+            - dict: courserun data.
         """
         data = super().run_pipeline(serialized_courserun=serialized_courserun)
         return data.get("serialized_courserun")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -42,8 +42,8 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
         a new page.
 
         Arguments:
-            - message: error message for the exception.
-            - redirect_to: URL to redirect to.
+            - message (str): error message for the exception.
+            - redirect_to (str): URL to redirect to.
         """
 
         def __init__(self, message: str, redirect_to: str) -> None:
@@ -58,15 +58,15 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
         template instead.
 
         Arguments:
-            - message: error message for the exception.
-            - account_settings_template: template path rendered instead.
-            - template_context: context used to the new account settings template.
+            - message (str): error message for the exception.
+            - account_settings_template (str): template path rendered instead.
+            - template_context (dict): context used to the new account settings template.
         """
 
         def __init__(
             self,
             message: str,
-            account_settings_template: str = "",
+            account_settings_template: Optional[str] = "",
             template_context: Optional[dict] = None
         ) -> None:
             """Initialize the exception with the message and the template path to render instead."""
@@ -84,11 +84,11 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            - message: error message for the exception.
-            - response: custom response which will be returned by the account settings view.
+            - message (str): error message for the exception.
+            - response (HttpResponse): custom response which will be returned by the account settings view.
         """
 
-        def __init__(self, message: str, response: Optional[dict] = None) -> None:
+        def __init__(self, message: str, response: Optional[HttpResponse] = None) -> None:
             """Initialize the exception with the message and the custom response to return."""
             super().__init__(message, response=response)
 
@@ -183,18 +183,18 @@ class StudentLoginRequested(OpenEdxPublicFilter):
         This exception is propagated to the login view and handled by the view to stop the login process.
 
         Arguments:
-            - message: error message for the exception.
-            - redirect_to: URL to redirect to.
-            - error_code: error code for the exception.
-            - context: context dictionary to be used in the exception.
+            - message (str): error message for the exception.
+            - redirect_to (str): URL to redirect to.
+            - error_code (str): error code for the exception.
+            - context (dict): context dictionary to be used in the exception.
         """
 
         def __init__(
             self,
             message: str,
-            redirect_to: str = "",
-            error_code: str = "",
-            context: dict = None
+            redirect_to: Optional[str] = "",
+            error_code: Optional[str] = "",
+            context: Optional[dict] = None
         ) -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to, error_code=error_code, context=context)
@@ -405,11 +405,11 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
         This exception is propagated to the certificate view and handled by the view to redirect the user to a new page.
 
         Arguments:
-            - message: error message for the exception.
-            - redirect_to: URL to redirect to.
+            - message (str): error message for the exception.
+            - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: str = "") -> None:
+        def __init__(self, message: str, redirect_to: Optional[str] = "") -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -421,11 +421,11 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            - message: error message for the exception.
-            - template_name: template path of the new certificate.
+            - message (str): error message for the exception.
+            - template_name (str): template path of the new certificate.
         """
 
-        def __init__(self, message: str, template_name: str = "") -> None:
+        def __init__(self, message: str, template_name: Optional[str] = "") -> None:
             """Initialize the exception with the message and the template path to render instead."""
             super().__init__(message, template_name=template_name)
 
@@ -437,8 +437,8 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            - message: error message for the exception.
-            - response: custom response which will be returned by the certificate view.
+            - message (str): error message for the exception.
+            - response (HttpResponse): custom response which will be returned by the certificate view.
         """
 
         def __init__(self, message: str, response: HttpResponse) -> None:
@@ -575,11 +575,11 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
         page.
 
         Arguments:
-            - message: error message for the exception.
-            - redirect_to: URL to redirect to.
+            - message (str): error message for the exception.
+            - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: str = "") -> None:
+        def __init__(self, message: str, redirect_to: Optional[str] = "") -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -591,12 +591,17 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            - message: error message for the exception.
-            - course_about_template: template path rendered instead.
-            - template_context: context used to the new course_about_template.
+            - message (Str): error message for the exception.
+            - course_about_template (str): template path rendered instead.
+            - template_context (dict): context used to the new course_about_template.
         """
 
-        def __init__(self, message: str, course_about_template: str = "", template_context: dict = None) -> None:
+        def __init__(
+            self,
+            message: str,
+            course_about_template: Optional[str] = "",
+            template_context: Optional[dict] = None
+        ) -> None:
             """Initialize the exception with the message and the template to render instead."""
             super().__init__(
                 message,
@@ -612,8 +617,8 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            - message: error message for the exception.
-            - response: custom response which will be returned by the course about view.
+            - message (str): error message for the exception.
+            - response (HttpResponse): custom response which will be returned by the course about view.
         """
 
         def __init__(self, message: str, response: HttpResponse) -> None:
@@ -668,11 +673,11 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         This exception is propagated to the dashboard view and handled by the view to redirect the user to a new page.
 
         Arguments:
-            - message: error message for the exception.
-            - redirect_to: URL to redirect to.
+            - message (str): error message for the exception.
+            - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: str = "") -> None:
+        def __init__(self, message: str, redirect_to: Optional[str] = "") -> None:
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -684,12 +689,17 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            - message: error message for the exception.
-            - dashboard_template: template path rendered instead.
-            - template_context: context used to the new dashboard_template.
+            - message (str): error message for the exception.
+            - dashboard_template (str): template path rendered instead.
+            - template_context (dict): context used to the new dashboard_template.
         """
 
-        def __init__(self, message: str, dashboard_template: str = "", template_context: dict = None) -> None:
+        def __init__(
+            self,
+            message: str,
+            dashboard_template: Optional[str] = "",
+            template_context: Optional[dict] = None
+        ) -> None:
             """Initialize the exception with the message and the template to render instead."""
             super().__init__(
                 message,
@@ -704,11 +714,11 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         This exception is propagated to the dashboard view and handled by the view to return a custom response instead.
 
         Arguments:
-            - message: error message for the exception.
-            - response: custom response which will be returned by the dashboard view.
+            - message (str): error message for the exception.
+            - response (HttpResponse): custom response which will be returned by the dashboard view.
         """
 
-        def __init__(self, message: str, response: HttpResponse = None) -> None:
+        def __init__(self, message: str, response: Optional[HttpResponse] = None) -> None:
             """Initialize the exception with the message and the custom response to return."""
             super().__init__(
                 message,
@@ -845,11 +855,11 @@ class RenderXBlockStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            message: error message for the exception.
-            response: custom response which will be returned by the XBlock render view.
+            message (str): error message for the exception.
+            response (HttpResponse): custom response which will be returned by the XBlock render view.
         """
 
-        def __init__(self, message: str, response: HttpResponse = None):
+        def __init__(self, message: str, response: Optional[HttpResponse] = None):
             """Initialize the exception with the message and the custom response to return."""
             super().__init__(message, response=response)
 
@@ -942,7 +952,7 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
 
         Arguments:
             course_key (CourseKey): The course key for which the home url is being requested.
-            course_home_url (String): The url string for the course home.
+            course_home_url (str): The url string for the course home.
 
         Returns:
             CourseKey: The course key for which the home url is being requested.
@@ -1046,11 +1056,11 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         new page.
 
         Arguments:
-            - message: error message for the exception.
-            - redirect_to: URL to redirect to.
+            - message (str): error message for the exception.
+            - redirect_to (str): URL to redirect to.
         """
 
-        def __init__(self, message: str, redirect_to: str = ""):
+        def __init__(self, message: str, redirect_to: Optional[str] = ""):
             """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
@@ -1062,12 +1072,17 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         template instead.
 
         Arguments:
-            - message: error message for the exception.
-            - instructor_template: template path rendered instead.
-            - template_context: context used to the new instructor_template.
+            - message (str): error message for the exception.
+            - instructor_template (str): template path rendered instead.
+            - template_context (dict): context used to the new instructor_template.
         """
 
-        def __init__(self, message: str, instructor_template: str = "", template_context: dict = None):
+        def __init__(
+            self,
+            message: str,
+            instructor_template: Optional[str] = "",
+            template_context: Optional[dict] = None
+        ):
             """Initialize the exception with the message and the template to render instead."""
             super().__init__(
                 message,
@@ -1083,11 +1098,11 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         response instead.
 
         Arguments:
-            - message: error message for the exception.
-            - response: custom response which will be returned by the dashboard view.
+            - message (str): error message for the exception.
+            - response (HttpResponse): custom response which will be returned by the dashboard view.
         """
 
-        def __init__(self, message: str, response: HttpResponse = None):
+        def __init__(self, message: str, response: Optional[HttpResponse] = None):
             """Initialize the exception with the message and the custom response to return."""
             super().__init__(
                 message,
@@ -1142,7 +1157,11 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template path rendered instead.
         """
 
-        def __init__(self, message: str, context: Optional[dict] = None, template_name: str = "") -> None:
+        def __init__(
+            self, message: str,
+            context: Optional[dict] = None,
+            template_name: Optional[str] = ""
+        ) -> None:
             """Initialize the exception with the message and the template to render instead."""
             super().__init__(message, context=context, template_name=template_name)
 

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -15,8 +15,10 @@ from openedx_filters.utils import SensitiveDataManagementMixin
 
 class AccountSettingsRenderStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the rendering of the account settings page in the LMS, triggered when a user
-    visits the page.
+    Filter used to modify the rendering of the account settings page in the LMS.
+
+    This filter is triggered when a user visits the account settings page, just before the page is rendered allowing
+    the filter to modify the context and the template used to render the page.
 
     Filter Type:
         org.openedx.learning.student.settings.render.started.v1
@@ -38,16 +40,14 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the account settings view and handled by the view to redirect the user to
         a new page.
+
+        Arguments:
+            - message: error message for the exception.
+            - redirect_to: URL to redirect to.
         """
 
         def __init__(self, message: str, redirect_to: str) -> None:
-            """
-            Initialize the exception with the message and the URL to redirect to.
-
-            Arguments:
-                - message: error message for the exception.
-                - redirect_to: URL to redirect to.
-            """
+            """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
     class RenderInvalidAccountSettings(OpenEdxFilterException):
@@ -56,6 +56,11 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the account settings view and handled by the view to render a different
         template instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - account_settings_template: template path rendered instead.
+            - template_context: context used to the new account settings template.
         """
 
         def __init__(
@@ -64,14 +69,7 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
             account_settings_template: str = "",
             template_context: Optional[dict] = None
         ) -> None:
-            """
-            Initialize the exception with the message and the template path to render instead.
-
-            Arguments:
-                - message: error message for the exception.
-                - account_settings_template: template path rendered instead.
-                - template_context: context used to the new account settings template.
-            """
+            """Initialize the exception with the message and the template path to render instead."""
             super().__init__(
                 message,
                 account_settings_template=account_settings_template,
@@ -84,23 +82,20 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the account settings view and handled by the view to return a custom response
         instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - response: custom response which will be returned by the account settings view.
         """
 
         def __init__(self, message: str, response: Optional[dict] = None) -> None:
-            """
-            Initialize the exception with the message and the custom response to return.
-
-            Arguments:
-                - message: error message for the exception.
-                - response: custom response which will be returned by the account settings view.
-            """
+            """Initialize the exception with the message and the custom response to return."""
             super().__init__(message, response=response)
 
     @classmethod
     def run_filter(cls, context: dict, template_name: str) -> tuple[dict, str]:
         """
-        Process the input context and template_name using the configured pipeline steps to modify the account settings
-        page.
+        Process the input context and template_name using the configured pipeline steps to modify the account settings.
 
         Arguments:
             - context (dict): template context for the account settings page.
@@ -165,7 +160,10 @@ class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementM
 
 class StudentLoginRequested(OpenEdxPublicFilter):
     """
-    Filter used to modify the login process, triggered when a user logins.
+    Filter used to modify the login process.
+
+    This filter is triggered when a user tries to log in, just before the login process is completed allowing the filter
+    to act on the user object.
 
     Filter Type:
         org.openedx.learning.student.login.requested.v1
@@ -183,6 +181,12 @@ class StudentLoginRequested(OpenEdxPublicFilter):
         Raise to prevent the login process to continue.
 
         This exception is propagated to the login view and handled by the view to stop the login process.
+
+        Arguments:
+            - message: error message for the exception.
+            - redirect_to: URL to redirect to.
+            - error_code: error code for the exception.
+            - context: context dictionary to be used in the exception.
         """
 
         def __init__(
@@ -192,15 +196,7 @@ class StudentLoginRequested(OpenEdxPublicFilter):
             error_code: str = "",
             context: dict = None
         ) -> None:
-            """
-            Initialize the exception with the message and the URL to redirect to.
-
-            Arguments:
-                - message: error message for the exception.
-                - redirect_to: URL to redirect to.
-                - error_code: error code for the exception.
-                - context: context dictionary to be used in the exception.
-            """
+            """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to, error_code=error_code, context=context)
 
     @classmethod
@@ -220,7 +216,10 @@ class StudentLoginRequested(OpenEdxPublicFilter):
 
 class CourseEnrollmentStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the course enrollment process, triggered when a user initiates the enrollment.
+    Filter used to modify the course enrollment process.
+
+    This filter is triggered when a user initiates the enrollment process, just before the enrollment is completed
+    allowing the filter to act on the user, course key, and mode.
 
     Filter Type:
         org.openedx.learning.course.enrollment.started.v1
@@ -264,7 +263,10 @@ class CourseEnrollmentStarted(OpenEdxPublicFilter):
 
 class CourseUnenrollmentStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the course unenrollment process, triggered when a user initiates the unenrollment.
+    Filter used to modify the course unenrollment process.
+
+    This filter is triggered when a user initiates the unenrollment process, just before the unenrollment is completed
+    allowing the filter to act on the user's enrollment in the course.
 
     Filter Type:
         org.openedx.learning.course.unenrollment.started.v1
@@ -302,7 +304,10 @@ class CourseUnenrollmentStarted(OpenEdxPublicFilter):
 
 class CertificateCreationRequested(OpenEdxPublicFilter):
     """
-    Filter used to modify the certificate creation process, triggered when a certificate starts to be generated.
+    Filter used to modify the certificate creation process.
+
+    This filter is triggered when a user requests a certificate, just before the certificate is created allowing the
+    filter to act on the user, course key, mode, status, grade, and generation mode.
 
     Usage:
         - Modify certificate parameters in runtime.
@@ -339,7 +344,7 @@ class CertificateCreationRequested(OpenEdxPublicFilter):
         generation_mode: str,
     ) -> tuple[Any, CourseKey, str, str, float, str]:
         """
-        Process the user, course_key, mode, status, grade, and generation_mode using the configured pipeline steps to
+        Process the inputs using the configured pipeline steps to modify the certificate creation process.
 
         Arguments:
             - user (User): Django User object.
@@ -348,6 +353,14 @@ class CertificateCreationRequested(OpenEdxPublicFilter):
             - status (str): specifies the status of the certificate.
             - grade (float): grade of the certificate.
             - generation_mode (str): specifies the mode of generation.
+
+        Returns:
+            - User: Django User object.
+            - CourseKey: course key associated with the certificate.
+            - str: mode of the certificate.
+            - str: status of the certificate.
+            - float: grade of the certificate.
+            - str: mode of generation.
         """
         data = super().run_pipeline(
             user=user,
@@ -369,7 +382,10 @@ class CertificateCreationRequested(OpenEdxPublicFilter):
 
 class CertificateRenderStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the certificate rendering process, triggered when a user begins rendering a certificate.
+    Filter used to modify the certificate rendering process.
+
+    This filter is triggered when a user requests to view the certificate, just before the certificate is rendered
+    allowing the filter to act on the context and the template used to render the certificate.
 
     Filter Type:
         org.openedx.learning.certificate.render.started.v1
@@ -387,16 +403,14 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
         Raise to redirect to a different page instead of rendering the certificate.
 
         This exception is propagated to the certificate view and handled by the view to redirect the user to a new page.
+
+        Arguments:
+            - message: error message for the exception.
+            - redirect_to: URL to redirect to.
         """
 
         def __init__(self, message: str, redirect_to: str = "") -> None:
-            """
-            Initialize the exception with the message and the URL to redirect to.
-
-            Arguments:
-                - message: error message for the exception.
-                - redirect_to: URL to redirect to.
-            """
+            """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
     class RenderAlternativeInvalidCertificate(OpenEdxFilterException):
@@ -405,16 +419,14 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the certificate view and handled by the view to render a different template
         instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - template_name: template path of the new certificate.
         """
 
         def __init__(self, message: str, template_name: str = "") -> None:
-            """
-            Initialize the exception with the message and the template path to render instead.
-
-            Arguments:
-                - message: error message for the exception.
-                - template_name: template path of the new certificate.
-            """
+            """Initialize the exception with the message and the template path to render instead."""
             super().__init__(message, template_name=template_name)
 
     class RenderCustomResponse(OpenEdxFilterException):
@@ -423,16 +435,14 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the certificate view and handled by the view to return a custom response
         instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - response: custom response which will be returned by the certificate view.
         """
 
         def __init__(self, message: str, response: HttpResponse) -> None:
-            """
-            Initialize the exception with the message and the custom response to return.
-
-            Arguments:
-                - message: error message for the exception.
-                - response: custom response which will be returned by the certificate view.
-            """
+            """Initialize the exception with the message and the custom response to return."""
             super().__init__(
                 message,
                 response=response,
@@ -446,6 +456,10 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
         Arguments:
             - context (dict): context dictionary for certificate template.
             - custom_template (CertificateTemplate): custom web certificate template.
+
+        Returns:
+            - dict: context dictionary for the certificate template, possibly modified.
+            - CertificateTemplate: custom web certificate template, possibly modified.
         """
         data = super().run_pipeline(context=context, custom_template=custom_template)
         return data.get("context"), data.get("custom_template")
@@ -453,7 +467,10 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
 
 class CohortChangeRequested(OpenEdxPublicFilter):
     """
-    Filter used to modify the cohort change process, triggered when a user changes cohorts.
+    Filter used to modify the cohort change process.
+
+    This filter is triggered when a user's cohort is changed, just before the change is completed allowing the filter
+    to act on the user and the target cohort.
 
     Filter Type:
         org.openedx.learning.cohort.change.requested.v1
@@ -476,12 +493,15 @@ class CohortChangeRequested(OpenEdxPublicFilter):
     @classmethod
     def run_filter(cls, current_membership: Any, target_cohort: Any) -> tuple[Any, Any]:
         """
-        Process the current_membership and target_cohort using the configured pipeline steps to modify the cohort
-        change process.
+        Process the inputs using the configured pipeline steps to modify the cohort change process.
 
         Arguments:
             - current_membership (CohortMembership): CohortMembership instance representing the current user's cohort.
             - target_cohort (CourseUserGroup): CourseUserGroup instance representing the new user's cohort.
+
+        Returns:
+            - CohortMembership: CohortMembership instance representing the current user's cohort.
+            - CourseUserGroup: CourseUserGroup instance representing the new user's cohort.
         """
         data = super().run_pipeline(current_membership=current_membership, target_cohort=target_cohort)
         return data.get("current_membership"), data.get("target_cohort")
@@ -489,7 +509,10 @@ class CohortChangeRequested(OpenEdxPublicFilter):
 
 class CohortAssignmentRequested(OpenEdxPublicFilter):
     """
-    Filter used to modify the cohort assignment process, triggered when a user is assigned to a new cohort.
+    Filter used to modify the cohort assignment process.
+
+    This filter is triggered when a user is assigned to a cohort, just before the assignment is completed allowing the
+    filter to act on the user and the target cohort.
 
     Filter Type:
         org.openedx.learning.cohort.assignment.requested.v1
@@ -515,8 +538,12 @@ class CohortAssignmentRequested(OpenEdxPublicFilter):
         Process the user and target_cohort using the configured pipeline steps to modify the cohort assignment process.
 
         Arguments:
-            - user (User): Django User object representing the new user.
+            - user (User): Django User object representing the user.
             - target_cohort (CourseUserGroup): CourseUserGroup instance representing the new user's cohort.
+
+        Returns:
+            - User: Django User object representing the user.
+            - CourseUserGroup: CourseUserGroup instance representing the new user's cohort.
         """
         data = super().run_pipeline(user=user, target_cohort=target_cohort)
         return data.get("user"), data.get("target_cohort")
@@ -524,8 +551,10 @@ class CohortAssignmentRequested(OpenEdxPublicFilter):
 
 class CourseAboutRenderStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the course about rendering process, triggered when a user requests to view the course about
-    page.
+    Filter used to modify the course about rendering process.
+
+    This filter is triggered when a user requests to view the course about page, just before the page is rendered
+    allowing the filter to act on the context and the template used to render the page.
 
     Filter Type:
         org.openedx.learning.course_about.render.started.v1
@@ -544,16 +573,14 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the course about view and handled by the view to redirect the user to a new
         page.
+
+        Arguments:
+            - message: error message for the exception.
+            - redirect_to: URL to redirect to.
         """
 
         def __init__(self, message: str, redirect_to: str = "") -> None:
-            """
-            Initialize the exception with the message and the URL to redirect to.
-
-            Arguments:
-                - message: error message for the exception.
-                - redirect_to: URL to redirect to.
-            """
+            """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
     class RenderInvalidCourseAbout(OpenEdxFilterException):
@@ -562,17 +589,15 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the course about view and handled by the view to render a different template
         instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - course_about_template: template path rendered instead.
+            - template_context: context used to the new course_about_template.
         """
 
         def __init__(self, message: str, course_about_template: str = "", template_context: dict = None) -> None:
-            """
-            Initialize the exception with the message and the template to render instead.
-
-            Arguments:
-                - message: error message for the exception.
-                - course_about_template: template path rendered instead.
-                - template_context: context used to the new course_about_template.
-            """
+            """Initialize the exception with the message and the template to render instead."""
             super().__init__(
                 message,
                 course_about_template=course_about_template,
@@ -585,16 +610,14 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the course about view and handled by the view to return a custom response
         instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - response: custom response which will be returned by the course about view.
         """
 
         def __init__(self, message: str, response: HttpResponse) -> None:
-            """
-            Initialize the exception with the message and the custom response to return.
-
-            Arguments:
-                - message: error message for the exception.
-                - response: custom response which will be returned by the course about view.
-            """
+            """Initialize the exception with the message and the custom response to return."""
             super().__init__(
                 message,
                 response=response,
@@ -608,6 +631,10 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
         Arguments:
             - context (dict): context dictionary for course about template.
             - template_name (str): template name to be rendered by the course about.
+
+        Returns:
+            - dict: context dictionary for the course about template, possibly modified.
+            - str: template name to be rendered by the course about, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -615,7 +642,10 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
 
 class DashboardRenderStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the dashboard rendering process, triggered when a user requests to view the student dashboard.
+    Filter used to modify the dashboard rendering process.
+
+    This filter is triggered when a user requests to view the dashboard, just before the page is rendered allowing the
+    filter to act on the context and the template used to render the page.
 
     Filter Type:
         org.openedx.learning.dashboard.render.started.v1
@@ -636,16 +666,14 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         Raise to redirect to a different page instead of rendering the dashboard.
 
         This exception is propagated to the dashboard view and handled by the view to redirect the user to a new page.
+
+        Arguments:
+            - message: error message for the exception.
+            - redirect_to: URL to redirect to.
         """
 
         def __init__(self, message: str, redirect_to: str = "") -> None:
-            """
-            Initialize the exception with the message and the URL to redirect to.
-
-            Arguments:
-                - message: error message for the exception.
-                - redirect_to: URL to redirect to.
-            """
+            """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
     class RenderInvalidDashboard(OpenEdxFilterException):
@@ -653,17 +681,16 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         Raise to render a different dashboard template instead of the default one.
 
         This exception is propagated to the dashboard view and handled by the view to render a different template
+        instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - dashboard_template: template path rendered instead.
+            - template_context: context used to the new dashboard_template.
         """
 
         def __init__(self, message: str, dashboard_template: str = "", template_context: dict = None) -> None:
-            """
-            Initialize the exception with the message and the template to render instead.
-
-            Arguments:
-                - message: error message for the exception.
-                - dashboard_template: template path rendered instead.
-                - template_context: context used to the new dashboard_template.
-            """
+            """Initialize the exception with the message and the template to render instead."""
             super().__init__(
                 message,
                 dashboard_template=dashboard_template,
@@ -675,16 +702,14 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         Raise to stop the dashboard rendering process and return a custom response.
 
         This exception is propagated to the dashboard view and handled by the view to return a custom response instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - response: custom response which will be returned by the dashboard view.
         """
 
         def __init__(self, message: str, response: HttpResponse = None) -> None:
-            """
-            Initialize the exception with the message and the custom response to return.
-
-            Arguments:
-                - message: error message for the exception.
-                - response: custom response which will be returned by the dashboard view.
-            """
+            """Initialize the exception with the message and the custom response to return."""
             super().__init__(
                 message,
                 response=response,
@@ -698,6 +723,10 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         Arguments:
             - context (dict): context dictionary for student's dashboard template.
             - template_name (str): template name to be rendered by the student's dashboard.
+
+        Returns:
+            - dict: context dictionary for the student's dashboard template, possibly modified.
+            - str: template name to be rendered by the student's dashboard, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -705,8 +734,10 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
 
 class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
     """
-    Filter used to modify the rendering of a child block within a vertical block, triggered when a child block starts
-    rendering.
+    Filter used to modify the rendering of a child block within a vertical block.
+
+    This filter is triggered when a child block is about to be rendered within a vertical block, allowing the filter to
+    act on the block and the context used to render the child block.
 
     Filter Type:
         org.openedx.learning.vertical_block_child.render.started.v1
@@ -735,6 +766,10 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
         Arguments:
             - block (XBlock): the XBlock that is about to be rendered into HTML
             - context (dict): rendering context values like is_mobile_app, show_title..etc
+
+        Returns:
+            - XBlock: the XBlock that is about to be rendered into HTML
+            - dict: rendering context values like is_mobile_app, show_title..etc
         """
         data = super().run_pipeline(block=block, context=context)
         return data.get("block"), data.get("context")
@@ -767,7 +802,10 @@ class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
         Process the enrollments QuerySet using the configured pipeline steps to modify the course enrollment data.
 
         Arguments:
-            - enrollments (QuerySet): data with all user's course enrollments
+            - enrollments (QuerySet): data with all user's course enrollments.
+
+        Returns:
+            - QuerySet: data with all user's course enrollments, possibly modified.
         """
         data = super().run_pipeline(enrollments=enrollments)
         return data.get("enrollments")
@@ -776,6 +814,9 @@ class CourseEnrollmentQuerysetRequested(OpenEdxPublicFilter):
 class RenderXBlockStarted(OpenEdxPublicFilter):
     """
     Filter in between context generation and rendering of XBlock scope.
+
+    This filter is triggered when an XBlock is about to be rendered, just before the rendering process is completed
+    allowing the filter to act on the context and student_view_context used to render the XBlock.
 
     Filter Type:
         org.openedx.learning.xblock.render.started.v1
@@ -802,27 +843,28 @@ class RenderXBlockStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the XBlock render view and handled by the view to return a custom response
         instead.
+
+        Arguments:
+            message: error message for the exception.
+            response: custom response which will be returned by the XBlock render view.
         """
 
         def __init__(self, message: str, response: HttpResponse = None):
-            """
-            Initialize the exception with the message and the custom response to return.
-
-            Arguments:
-                message: error message for the exception.
-                response: custom response which will be returned by the XBlock render view.
-            """
+            """Initialize the exception with the message and the custom response to return."""
             super().__init__(message, response=response)
 
     @classmethod
     def run_filter(cls, context: dict, student_view_context: dict):
         """
-        Process the context and student_view_context using the configured pipeline steps to modify the rendering of an
-        XBlock.
+        Process the inputs using the configured pipeline steps to modify the rendering of an XBlock.
 
         Arguments:
             - context (dict): rendering context values like is_mobile_app, show_title, etc.
-            - student_view_context (dict): context passed to the student_view of the block context
+            - student_view_context (dict): context passed to the student_view of the block context.
+
+        Returns:
+            - dict: rendering context values like is_mobile_app, show_title, etc.
+            - dict: context passed to the student_view of the block context.
         """
         data = super().run_pipeline(context=context, student_view_context=student_view_context)
         return data.get("context"), data.get("student_view_context")
@@ -831,6 +873,9 @@ class RenderXBlockStarted(OpenEdxPublicFilter):
 class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
     """
     Filter used to act on vertical block rendering completed.
+
+    This filter is triggered when a vertical block is rendered, just after the rendering process is completed allowing
+    the filter to act on the block, fragment, context, and view used to render the vertical block.
 
     Filter Type:
         org.openedx.learning.vertical_block.render.completed.v1
@@ -854,14 +899,19 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
     @classmethod
     def run_filter(cls, block: Any, fragment: Any, context: dict, view: str) -> tuple[Any, Any, dict, str]:
         """
-        Process the block, fragment, context, and view using the configured pipeline steps to modify the rendering of a
-        vertical block.
+        Process the inputs using the configured pipeline steps to modify the rendering of a vertical block.
 
         Arguments:
             - block (VerticalBlock): The VeriticalBlock instance which is being rendered.
             - fragment (web_fragments.Fragment): The web-fragment containing the rendered content of VerticalBlock.
             - context (dict): rendering context values like is_mobile_app, show_title..etc.
             - view (str): the rendering view. Can be either 'student_view', or 'public_view'.
+
+        Returns:
+            - VerticalBlock: The VeriticalBlock instance which is being rendered.
+            - web_fragments.Fragment: The web-fragment containing the rendered content of VerticalBlock.
+            - dict: rendering context values like is_mobile_app, show_title..etc.
+            - str: the rendering view. Can be either 'student_view', or 'public_view'.
         """
         data = super().run_pipeline(block=block, fragment=fragment, context=context, view=view)
         return data.get("block"), data.get("fragment"), data.get("context"), data.get("view")
@@ -870,6 +920,9 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
 class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
     """
     Filter used to modify the course home url creation process.
+
+    This filter is triggered when a course home url is being generated, just before the generation process is completed
+    allowing the filter to act on the course key and course home url.
 
     Filter Type:
         org.openedx.learning.course.homepage.url.creation.started.v1
@@ -889,7 +942,11 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
 
         Arguments:
             course_key (CourseKey): The course key for which the home url is being requested.
-            course_home_url (String): The url string for the course home
+            course_home_url (String): The url string for the course home.
+
+        Returns:
+            CourseKey: The course key for which the home url is being requested.
+            str: The url string for the course home.
         """
         data = super().run_pipeline(course_key=course_key, course_home_url=course_home_url)
         return data.get("course_key"), data.get("course_home_url")
@@ -898,6 +955,9 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
 class CourseEnrollmentAPIRenderStarted(OpenEdxPublicFilter):
     """
     Filter used to modify the course enrollment API rendering process.
+
+    This filter is triggered when a user requests to view the course enrollment API, just before the API is rendered
+    allowing the filter to act on the course key and serialized enrollment data.
 
     Filter Type:
         org.openedx.learning.home.enrollment.api.rendered.v1
@@ -913,12 +973,15 @@ class CourseEnrollmentAPIRenderStarted(OpenEdxPublicFilter):
     @classmethod
     def run_filter(cls, course_key: CourseKey, serialized_enrollment: dict) -> tuple[CourseKey, dict]:
         """
-        Process the course_key and serialized_enrollment using the configured pipeline steps to modify the course
-        enrollment data.
+        Process the inputs using the configured pipeline steps to modify the course enrollment data.
 
         Arguments:
-            course_key (CourseKey): The course key for which isStarted is being modify.
-            serialized_enrollment (dict): enrollment data
+            - course_key (CourseKey): The course key for which isStarted is being modify.
+            - serialized_enrollment (dict): enrollment data.
+
+        Returns:
+            - CourseKey: The course key for which isStarted is being modify.
+            - dict: enrollment data.
         """
         data = super().run_pipeline(course_key=course_key, serialized_enrollment=serialized_enrollment)
         return data.get("course_key"), data.get("serialized_enrollment")
@@ -927,6 +990,9 @@ class CourseEnrollmentAPIRenderStarted(OpenEdxPublicFilter):
 class CourseRunAPIRenderStarted(OpenEdxPublicFilter):
     """
     Filter used to modify the course run API rendering process.
+
+    This filter is triggered when a user requests to view the course run API, just before the API is rendered allowing
+    the filter to act on the serialized course run data.
 
     Filter Type:
         org.openedx.learning.home.courserun.api.rendered.started.v1
@@ -946,6 +1012,9 @@ class CourseRunAPIRenderStarted(OpenEdxPublicFilter):
 
         Arguments:
             serialized_courserun (dict): courserun data.
+
+        Returns:
+            dict: courserun data.
         """
         data = super().run_pipeline(serialized_courserun=serialized_courserun)
         return data.get("serialized_courserun")
@@ -954,6 +1023,9 @@ class CourseRunAPIRenderStarted(OpenEdxPublicFilter):
 class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
     """
     Filter used to modify the instructor dashboard rendering process.
+
+    This filter is triggered when an instructor requests to view the dashboard, just before the page is rendered
+    allowing the filter to act on the context and the template used to render the page.
 
     Filter Type:
         org.openedx.learning.instructor.dashboard.render.started.v1
@@ -972,16 +1044,14 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the instructor dashboard view and handled by the view to redirect the user to a
         new page.
+
+        Arguments:
+            - message: error message for the exception.
+            - redirect_to: URL to redirect to.
         """
 
         def __init__(self, message: str, redirect_to: str = ""):
-            """
-            Initialize the exception with the message and the URL to redirect to.
-
-            Arguments:
-                - message: error message for the exception.
-                - redirect_to: URL to redirect to.
-            """
+            """Initialize the exception with the message and the URL to redirect to."""
             super().__init__(message, redirect_to=redirect_to)
 
     class RenderInvalidDashboard(OpenEdxFilterException):
@@ -990,17 +1060,15 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the instructor dashboard view and handled by the view to render a different
         template instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - instructor_template: template path rendered instead.
+            - template_context: context used to the new instructor_template.
         """
 
         def __init__(self, message: str, instructor_template: str = "", template_context: dict = None):
-            """
-            Initialize the exception with the message and the template to render instead.
-
-            Arguments:
-                - message: error message for the exception.
-                - instructor_template: template path rendered instead.
-                - template_context: context used to the new instructor_template.
-            """
+            """Initialize the exception with the message and the template to render instead."""
             super().__init__(
                 message,
                 instructor_template=instructor_template,
@@ -1013,16 +1081,14 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the instructor dashboard view and handled by the view to return a custom
         response instead.
+
+        Arguments:
+            - message: error message for the exception.
+            - response: custom response which will be returned by the dashboard view.
         """
 
         def __init__(self, message: str, response: HttpResponse = None):
-            """
-            Initialize the exception with the message and the custom response to return.
-
-            Arguments:
-                - message: error message for the exception.
-                - response: custom response which will be returned by the dashboard view.
-            """
+            """Initialize the exception with the message and the custom response to return."""
             super().__init__(
                 message,
                 response=response,
@@ -1038,7 +1104,8 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template name to be rendered by the instructor's tab.
 
         Returns:
-            - tuple: context dictionary and template name.
+            - dict: context dictionary for the instructor's tab template, possibly modified.
+            - str: template name to be rendered by the instructor's tab, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -1047,6 +1114,9 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
 class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
     """
     Filter used to modify the submission view rendering process.
+
+    This filter is triggered when a user requests to view the submission, just before the page is rendered allowing the
+    filter to act on the context and the template used to render the page.
 
     Filter Type:
         org.openedx.learning.ora.submission_view.render.started.v1
@@ -1065,17 +1135,15 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
 
         This exception is propagated to the submission view and handled by the view to render a different template
         instead.
+
+        Arguments:
+            - message (str): error message for the exception.
+            - context (dict): context used to the submission view template.
+            - template_name (str): template path rendered instead.
         """
 
         def __init__(self, message: str, context: Optional[dict] = None, template_name: str = "") -> None:
-            """
-            Initialize the exception with the message and the template to render instead.
-
-            Arguments:
-                - message (str): error message for the exception.
-                - context (dict): context used to the submission view template.
-                - template_name (str): template path rendered instead.
-            """
+            """Initialize the exception with the message and the template to render instead."""
             super().__init__(message, context=context, template_name=template_name)
 
     @classmethod
@@ -1084,8 +1152,12 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
         Process the context and template_name using the configured pipeline steps to modify the submission view.
 
         Arguments:
-            context (dict): context dictionary for submission view template.
-            template_name (str): template name to be rendered by the student's dashboard.
+            - context (dict): context dictionary for submission view template.
+            - template_name (str): template name to be rendered by the student's dashboard.
+
+        Returns:
+            - dict: context dictionary for the submission view template, possibly modified.
+            - str: template name to be rendered by the submission view, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name, )
         return data.get("context"), data.get("template_name")
@@ -1094,6 +1166,9 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
 class IDVPageURLRequested(OpenEdxPublicFilter):
     """
     Filter used to act on ID verification page URL requests.
+
+    This filter is triggered when a user requests to view the ID verification page, just before the page is rendered
+    allowing the filter to act on the URL of the page.
 
     Filter Type:
         org.openedx.learning.idv.page.url.requested.v1
@@ -1113,6 +1188,9 @@ class IDVPageURLRequested(OpenEdxPublicFilter):
 
         Arguments:
             - url (str): The url for the ID verification page to be modified.
+
+        Returns:
+            - str: The modified URL for the ID verification page.
         """
         data = super().run_pipeline(url=url)
         return data.get("url")
@@ -1121,6 +1199,17 @@ class IDVPageURLRequested(OpenEdxPublicFilter):
 class CourseAboutPageURLRequested(OpenEdxPublicFilter):
     """
     Filter used to act on course about page URL requests.
+
+    This filter is triggered when a user requests to view the course about page, just before the page is rendered
+    allowing the filter to act on the URL of the page and the course org.
+
+    Filter Type:
+        org.openedx.learning.course_about.page.url.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: common/djangoapps/util/course.py
+        - Function or Method: get_link_for_about_page
     """
 
     filter_type = "org.openedx.learning.course_about.page.url.requested.v1"
@@ -1133,6 +1222,10 @@ class CourseAboutPageURLRequested(OpenEdxPublicFilter):
         Arguments:
             - url (str): the URL of the page to be modified.
             - org (str): Course org filter used as context data to get LMS configurations.
+
+        Returns:
+            - str: the modified URL of the page.
+            - str: Course org filter used as context data to get LMS configurations
         """
         data = super().run_pipeline(url=url, org=org)
         return data.get("url"), data.get("org")

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -862,8 +862,8 @@ class RenderXBlockStarted(OpenEdxPublicFilter):
         instead.
 
         Arguments:
-            message (str): error message for the exception.
-            response (HttpResponse): custom response which will be returned by the XBlock render view.
+            - message (str): error message for the exception.
+            - response (HttpResponse): custom response which will be returned by the XBlock render view.
         """
 
         def __init__(self, message: str, response: Optional[HttpResponse] = None):

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -5,7 +5,7 @@ Package where filters related to the learning architectural subdomain are implem
 from typing import Any, Optional
 
 from django.db.models.query import QuerySet
-from django.http import HttpResponse
+from django.http import HttpResponse, QueryDict
 from opaque_keys.edx.keys import CourseKey
 
 from openedx_filters.exceptions import OpenEdxFilterException
@@ -102,8 +102,9 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template path used to render the account settings page.
 
         Returns:
-            - dict: context dictionary for the account settings page, possibly modified.
-            - str: template name to be rendered by the account settings page, possibly modified.
+            tuple[dict, str]:
+                - dict: context dictionary for the account settings page, possibly modified.
+                - str: template name to be rendered by the account settings page, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -141,7 +142,7 @@ class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementM
         """
 
     @classmethod
-    def run_filter(cls, form_data: dict) -> dict:
+    def run_filter(cls, form_data: QueryDict) -> QueryDict:
         """
         Process the registration form data using the configured pipeline steps to modify the registration process.
 
@@ -149,7 +150,7 @@ class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementM
             - form_data (QueryDict): contains the request.data submitted by the registration form.
 
         Returns:
-            - dict: form data dictionary, possibly modified.
+            - QueryDict: form data dictionary, possibly modified.
         """
         sensitive_data = cls.extract_sensitive_data(form_data)
         data = super().run_pipeline(form_data=form_data)
@@ -458,8 +459,9 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
             - custom_template (CertificateTemplate): custom web certificate template.
 
         Returns:
-            - dict: context dictionary for the certificate template, possibly modified.
-            - CertificateTemplate: custom web certificate template, possibly modified.
+            tuple[dict, CertificateTemplate]:
+                - dict: context dictionary for the certificate template, possibly modified.
+                - CertificateTemplate: custom web certificate template, possibly modified.
         """
         data = super().run_pipeline(context=context, custom_template=custom_template)
         return data.get("context"), data.get("custom_template")
@@ -500,8 +502,9 @@ class CohortChangeRequested(OpenEdxPublicFilter):
             - target_cohort (CourseUserGroup): CourseUserGroup instance representing the new user's cohort.
 
         Returns:
-            - CohortMembership: CohortMembership instance representing the current user's cohort.
-            - CourseUserGroup: CourseUserGroup instance representing the new user's cohort.
+            tuple[CohortMembership, CourseUserGroup]:
+                - CohortMembership: CohortMembership instance representing the current user's cohort.
+                - CourseUserGroup: CourseUserGroup instance representing the new user's cohort.
         """
         data = super().run_pipeline(current_membership=current_membership, target_cohort=target_cohort)
         return data.get("current_membership"), data.get("target_cohort")
@@ -542,8 +545,9 @@ class CohortAssignmentRequested(OpenEdxPublicFilter):
             - target_cohort (CourseUserGroup): CourseUserGroup instance representing the new user's cohort.
 
         Returns:
-            - User: Django User object representing the user.
-            - CourseUserGroup: CourseUserGroup instance representing the new user's cohort.
+            tuple[User, CourseUserGroup]:
+                - User: Django User object representing the user.
+                - CourseUserGroup: CourseUserGroup instance representing the new user's cohort.
         """
         data = super().run_pipeline(user=user, target_cohort=target_cohort)
         return data.get("user"), data.get("target_cohort")
@@ -638,8 +642,9 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template name to be rendered by the course about.
 
         Returns:
-            - dict: context dictionary for the course about template, possibly modified.
-            - str: template name to be rendered by the course about, possibly modified.
+            tuple[dict, str]:
+                - dict: context dictionary for the course about template, possibly modified.
+                - str: template name to be rendered by the course about, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -735,8 +740,9 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template name to be rendered by the student's dashboard.
 
         Returns:
-            - dict: context dictionary for the student's dashboard template, possibly modified.
-            - str: template name to be rendered by the student's dashboard, possibly modified.
+            tuple[dict, str]:
+                - dict: context dictionary for the student's dashboard template, possibly modified.
+                - str: template name to be rendered by the student's dashboard, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -778,8 +784,9 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
             - context (dict): rendering context values like is_mobile_app, show_title..etc
 
         Returns:
-            - XBlock: the XBlock that is about to be rendered into HTML
-            - dict: rendering context values like is_mobile_app, show_title..etc
+            tuple[XBlock, dict]:
+                - XBlock: the XBlock that is about to be rendered into HTML
+                - dict: rendering context values like is_mobile_app, show_title..etc
         """
         data = super().run_pipeline(block=block, context=context)
         return data.get("block"), data.get("context")
@@ -873,8 +880,9 @@ class RenderXBlockStarted(OpenEdxPublicFilter):
             - student_view_context (dict): context passed to the student_view of the block context.
 
         Returns:
-            - dict: rendering context values like is_mobile_app, show_title, etc.
-            - dict: context passed to the student_view of the block context.
+            tuple[dict, dict]:
+                - dict: rendering context values like is_mobile_app, show_title, etc.
+                - dict: context passed to the student_view of the block context.
         """
         data = super().run_pipeline(context=context, student_view_context=student_view_context)
         return data.get("context"), data.get("student_view_context")
@@ -955,8 +963,9 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
             course_home_url (str): The url string for the course home.
 
         Returns:
-            CourseKey: The course key for which the home url is being requested.
-            str: The url string for the course home.
+            tuple[CourseKey, str]:
+                CourseKey: The course key for which the home url is being requested.
+                str: The url string for the course home.
         """
         data = super().run_pipeline(course_key=course_key, course_home_url=course_home_url)
         return data.get("course_key"), data.get("course_home_url")
@@ -990,8 +999,9 @@ class CourseEnrollmentAPIRenderStarted(OpenEdxPublicFilter):
             - serialized_enrollment (dict): enrollment data.
 
         Returns:
-            - CourseKey: The course key for which isStarted is being modify.
-            - dict: enrollment data.
+            tuple[CourseKey, dict]:
+                - CourseKey: The course key for which isStarted is being modify.
+                - dict: enrollment data.
         """
         data = super().run_pipeline(course_key=course_key, serialized_enrollment=serialized_enrollment)
         return data.get("course_key"), data.get("serialized_enrollment")
@@ -1119,8 +1129,9 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template name to be rendered by the instructor's tab.
 
         Returns:
-            - dict: context dictionary for the instructor's tab template, possibly modified.
-            - str: template name to be rendered by the instructor's tab, possibly modified.
+            tuple[dict, str]:
+                - dict: context dictionary for the instructor's tab template, possibly modified.
+                - str: template name to be rendered by the instructor's tab, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
@@ -1175,8 +1186,9 @@ class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
             - template_name (str): template name to be rendered by the student's dashboard.
 
         Returns:
-            - dict: context dictionary for the submission view template, possibly modified.
-            - str: template name to be rendered by the submission view, possibly modified.
+            tuple[dict, str]:
+                - dict: context dictionary for the submission view template, possibly modified.
+                - str: template name to be rendered by the submission view, possibly modified.
         """
         data = super().run_pipeline(context=context, template_name=template_name, )
         return data.get("context"), data.get("template_name")
@@ -1243,8 +1255,9 @@ class CourseAboutPageURLRequested(OpenEdxPublicFilter):
             - org (str): Course org filter used as context data to get LMS configurations.
 
         Returns:
-            - str: the modified URL of the page.
-            - str: Course org filter used as context data to get LMS configurations
+            tuple[str, str]:
+                - str: the modified URL of the page.
+                - str: Course org filter used as context data to get LMS configurations.
         """
         data = super().run_pipeline(url=url, org=org)
         return data.get("url"), data.get("org")

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,4 +2,4 @@
 -c constraints.txt
 
 django
-
+edx-opaque-keys[django]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,5 +10,17 @@ django==4.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
+dnspython==2.7.0
+    # via pymongo
+edx-opaque-keys[django]==2.11.0
+    # via -r requirements/base.in
+pbr==6.1.0
+    # via stevedore
+pymongo==4.10.1
+    # via edx-opaque-keys
 sqlparse==0.5.3
     # via django
+stevedore==5.4.0
+    # via edx-opaque-keys
+typing-extensions==4.12.2
+    # via edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -86,11 +86,17 @@ django==4.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
+dnspython==2.7.0
+    # via
+    #   -r requirements/quality.txt
+    #   pymongo
 docutils==0.21.2
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
 edx-lint==5.4.1
+    # via -r requirements/quality.txt
+edx-opaque-keys[django]==2.11.0
     # via -r requirements/quality.txt
 filelock==3.16.1
     # via
@@ -232,6 +238,10 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pymongo==4.10.1
+    # via
+    #   -r requirements/quality.txt
+    #   edx-opaque-keys
 pyproject-api==1.8.0
     # via
     #   -r requirements/ci.txt
@@ -299,6 +309,7 @@ stevedore==5.4.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/quality.txt
@@ -311,7 +322,11 @@ tox==4.23.2
     # via -r requirements/ci.txt
 twine==6.0.1
     # via -r requirements/quality.txt
-urllib3==2.2.3
+typing-extensions==4.12.2
+    # via
+    #   -r requirements/quality.txt
+    #   edx-opaque-keys
+urllib3==2.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -53,6 +53,10 @@ django==4.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
+dnspython==2.7.0
+    # via
+    #   -r requirements/test.txt
+    #   pymongo
 doc8==1.1.2
     # via -r requirements/doc.in
 docutils==0.21.2
@@ -62,6 +66,8 @@ docutils==0.21.2
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
+edx-opaque-keys[django]==2.11.0
+    # via -r requirements/test.txt
 h11==0.14.0
     # via uvicorn
 idna==3.10
@@ -136,6 +142,10 @@ pygments==2.19.1
     #   readme-renderer
     #   rich
     #   sphinx
+pymongo==4.10.1
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
 pyproject-hooks==1.2.0
     # via build
 pytest==8.3.4
@@ -221,6 +231,7 @@ stevedore==5.4.0
     #   -r requirements/test.txt
     #   code-annotations
     #   doc8
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt
@@ -229,7 +240,9 @@ twine==6.0.1
     # via -r requirements/doc.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements/test.txt
     #   anyio
+    #   edx-opaque-keys
     #   pydata-sphinx-theme
 urllib3==2.2.3
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -46,10 +46,16 @@ django==4.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
+dnspython==2.7.0
+    # via
+    #   -r requirements/test.txt
+    #   pymongo
 docutils==0.21.2
     # via readme-renderer
 edx-lint==5.4.1
     # via -r requirements/quality.in
+edx-opaque-keys[django]==2.11.0
+    # via -r requirements/test.txt
 idna==3.10
     # via requests
 importlib-metadata==8.5.0
@@ -135,6 +141,10 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pymongo==4.10.1
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
 pytest==8.3.4
     # via
     #   -r requirements/test.txt
@@ -178,6 +188,7 @@ stevedore==5.4.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt
@@ -186,7 +197,11 @@ tomlkit==0.13.2
     # via pylint
 twine==6.0.1
     # via -r requirements/quality.in
-urllib3==2.2.3
+typing-extensions==4.12.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+urllib3==2.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,6 +20,12 @@ django==4.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+dnspython==2.7.0
+    # via
+    #   -r requirements/base.txt
+    #   pymongo
+edx-opaque-keys[django]==2.11.0
+    # via -r requirements/base.txt
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.5
@@ -29,9 +35,15 @@ markupsafe==3.0.2
 packaging==24.2
     # via pytest
 pbr==6.1.0
-    # via stevedore
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
 pluggy==1.5.0
     # via pytest
+pymongo==4.10.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
 pytest==8.3.4
     # via
     #   pytest-cov
@@ -49,6 +61,13 @@ sqlparse==0.5.3
     #   -r requirements/base.txt
     #   django
 stevedore==5.4.0
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
+typing-extensions==4.12.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys


### PR DESCRIPTION
## Description

This PR modifies the docstrings of all current filters by adding:

- Better descriptions of their purpose.
- Typing hints.
- Filter type embedded in the docstring to be reflected in the docs generated by RTD.
- Trigger information to locate the filter in the corresponding services.

## Supporting information

This PR addresses a concern raised by this PR removing hooks docs from edx-platform: https://github.com/openedx/edx-platform/pull/35921#issue-2690350343, where the table referencing where each event was triggered from was dropped.

## Testing instructions

You can review the changes here: https://docsopenedxorg--246.org.readthedocs.build/projects/openedx-filters/en/246/reference/filters.html

## Deadline

None

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Code dependencies reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
