### PR TITLE
feat: replace `pydocstyle` with `ruff`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ quality: ## check coding style with pycodestyle and pylint
 	pylint openedx_filters test_utils *.py
 	mypy
 	pycodestyle openedx_filters  *.py
-	pydocstyle openedx_filters *.py
+	ruff check openedx_filters *.py
 	isort --check-only --diff --recursive test_utils openedx_filters *.py test_settings.py
 	python setup.py bdist_wheel
 	twine check dist/*

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -225,8 +225,6 @@ pycparser==2.22
     # via
     #   -r requirements/quality.txt
     #   cffi
-pydocstyle==6.3.0
-    # via -r requirements/quality.txt
 pygments==2.19.1
     # via
     #   -r requirements/quality.txt
@@ -315,10 +313,6 @@ six==1.17.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-snowballstemmer==2.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   pydocstyle
 sqlparse==0.5.3
     # via
     #   -r requirements/quality.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -305,6 +305,8 @@ rich==13.9.4
     # via
     #   -r requirements/quality.txt
     #   twine
+ruff==0.9.8
+    # via -r requirements/quality.txt
 secretstorage==3.3.3
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -243,7 +243,11 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
+<<<<<<< HEAD
 starlette==0.46.1
+=======
+starlette==0.46.0
+>>>>>>> 1dd355b (chore(deps): add ruff to quality.in requirements)
     # via sphinx-autobuild
 stevedore==5.4.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -243,11 +243,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-<<<<<<< HEAD
 starlette==0.46.1
-=======
-starlette==0.46.0
->>>>>>> 1dd355b (chore(deps): add ruff to quality.in requirements)
     # via sphinx-autobuild
 stevedore==5.4.1
     # via

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -6,7 +6,6 @@
 edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
-pydocstyle                # PEP 257 compliance validation
 twine                     # Utility for publishing Python packages on PyPI.
 mypy                      # Static type checker
 ruff                      # A modern Python code linter and formatter.

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -9,3 +9,4 @@ pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
 twine                     # Utility for publishing Python packages on PyPI.
 mypy                      # Static type checker
+ruff                      # A modern Python code linter and formatter.

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -192,6 +192,8 @@ rfc3986==2.0.0
     # via twine
 rich==13.9.4
     # via twine
+ruff==0.9.8
+    # via -r requirements/quality.in
 secretstorage==3.3.3
     # via keyring
 six==1.17.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -138,8 +138,6 @@ pycodestyle==2.12.1
     # via -r requirements/quality.in
 pycparser==2.22
     # via cffi
-pydocstyle==6.3.0
-    # via -r requirements/quality.in
 pygments==2.19.1
     # via
     #   readme-renderer
@@ -198,8 +196,6 @@ secretstorage==3.3.3
     # via keyring
 six==1.17.0
     # via edx-lint
-snowballstemmer==2.2.0
-    # via pydocstyle
 sqlparse==0.5.3
     # via
     #   -r requirements/test.txt

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
 [lint]
-# D: pydocstyle
-select = ["D"]
+select = [
+    "D", # pydocstyle
+]
+
 ignore = [
     "D101", # Missing docstring in public class
     "D200", # One-line docstring should fit on one line

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,22 @@
+[lint]
+# D: pydocstyle
+select = ["D"]
+ignore = [
+    "D101", # Missing docstring in public class
+    "D200", # One-line docstring should fit on one line
+    "D212", # Multi-line docstring summary should start at the first line
+    "D405", # Section name should be properly capitalized
+    "D410", # Missing blank line after section
+    "D411", # Missing blank line before section
+    "D412", # No blank lines allowed between a section header and its content
+    "D414", # Section has no content,
+
+    # Ignore all other pydocstyle errors
+    "D102", # Missing docstring in public method
+    "D205", # 1 blank line required between summary line and description
+    "D415", # First line should end with a period, question mark, or exclamation point
+]
+
+[lint.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,20 +5,24 @@ select = [
 
 ignore = [
     "D101", # Missing docstring in public class
+    "D102", # Missing docstring in public method
     "D200", # One-line docstring should fit on one line
+    "D203", # 1 blank line required before class docstring
+    "D205", # 1 blank line required between summary line and description
     "D212", # Multi-line docstring summary should start at the first line
+    "D215", # Section underline is over-indented
+    "D400", # First line should end with a period
+    "D401", # First line of docstring should be in imperative mood
+    "D404", # First word of the docstring should not be "This"
     "D405", # Section name should be properly capitalized
+    "D406", # Section name should end with a newline
+    "D407", # Missing dashed underline after section
+    "D408", # Section underline should be in the line following the section's name
+    "D409", # Section underline should match the length of its name
     "D410", # Missing blank line after section
     "D411", # Missing blank line before section
     "D412", # No blank lines allowed between a section header and its content
-    "D414", # Section has no content,
-
-    # Ignore all other pydocstyle errors
-    "D102", # Missing docstring in public method
-    "D205", # 1 blank line required between summary line and description
+    "D413", # Missing blank line after last section
+    "D414", # Section has no content
     "D415", # First line should end with a period, question mark, or exclamation point
 ]
-
-[lint.pydocstyle]
-# Use Google-style docstrings.
-convention = "google"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = py{311, 312}-django{42}, quality, docs
 
-
 [doc8]
 ; D001 = Line too long
 ignore=D001
@@ -10,26 +9,6 @@ ignore=D001
 exclude = .git,.tox
 max-line-length = 120
 max-doc-length = 120
-
-[pydocstyle]
-; D101 = Missing docstring in public class
-; D200 = One-line docstring should fit on one line with quotes
-; D203 = 1 blank line required before class docstring
-; D212 = Multi-line docstring summary should start at the first line
-; D215 = Section underline is over-indented (numpy style)
-; D404 = First word of the docstring should not be This (numpy style)
-; D405 = Section name should be properly capitalized (numpy style)
-; D406 = Section name should end with a newline (numpy style)
-; D407 = Missing dashed underline after section (numpy style)
-; D408 = Section underline should be in the line following the section's name (numpy style)
-; D409 = Section underline should match the length of its name (numpy style)
-; D410 = Missing blank line after section (numpy style)
-; D411 = Missing blank line before section (numpy style)
-; D412 = No blank lines allowed between a section header and its content (numpy style)
-; D413 = Missing blank line after last section (numpy style)
-; D414 = Section has no content (numpy style)
-ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
-
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_utils.test_settings


### PR DESCRIPTION
## Description

This PR replaces the [`pydocstyle`](https://github.com/PyCQA/pydocstyle) deprecated library with [`ruff`](https://docs.astral.sh/ruff/).

It's important to note that **ruff** can replace other packages such as `pylint`, `pycodestyle`, and `isort`. This is just the initial step to fully implement a faster and modern tool.

## Testing instructions

You can run `make quality` in your local or see the PR checks.

## Deadline

None

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Code dependencies reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
