### PR TITLE
[POC] feat: replace `pycodestyle`, `isort` and `pylint` with `ruff`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ upgrade:  ## update the requirements/*.txt files with the latest packages satisf
 quality: ## check coding style with pycodestyle and pylint
 	pylint openedx_filters test_utils *.py
 	mypy
-	ruff check test_utils openedx_filters --preview
+	ruff check test_utils openedx_filters
 	python setup.py bdist_wheel
 	twine check dist/*
 	make selfcheck

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,10 @@ upgrade:  ## update the requirements/*.txt files with the latest packages satisf
 quality: ## check coding style with pycodestyle and pylint
 	pylint openedx_filters test_utils *.py
 	mypy
-	pycodestyle openedx_filters  *.py
-	ruff check openedx_filters *.py
-	isort --check-only --diff --recursive test_utils openedx_filters *.py test_settings.py
+	ruff check test_utils openedx_filters --preview
 	python setup.py bdist_wheel
 	twine check dist/*
 	make selfcheck
-
 
 requirements: ## install development environment requirements
 	pip install -r requirements/pip.txt

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import
+            import django  # pylint: disable=unused-import # noqa: F401
         except ImportError as error:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -1,6 +1,6 @@
 """
 Filters of the Open edX platform.
 """
-from openedx_filters.filters import *
+from openedx_filters.filters import *  # noqa: F403
 
 __version__ = "2.1.0"

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -368,7 +368,7 @@ class CertificateCreationRequested(OpenEdxPublicFilter):
         """
 
     @classmethod
-    def run_filter(  # pylint: disable=too-many-positional-arguments
+    def run_filter(  # pylint: disable=too-many-positional-arguments # noqa: PLR0917
         cls,
         user: Any,
         course_key: CourseKey,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,11 @@
 #
 #    make upgrade
 #
+<<<<<<< HEAD
 asgiref==3.10.0
+=======
+asgiref==3.9.2
+>>>>>>> 8dd1b47 (chore: upgrade requirements)
     # via django
 django==4.2.25
     # via
@@ -14,7 +18,11 @@ dnspython==2.8.0
     # via pymongo
 edx-opaque-keys[django]==3.0.0
     # via -r requirements/base.in
+<<<<<<< HEAD
 pymongo==4.15.2
+=======
+pymongo==4.15.1
+>>>>>>> 8dd1b47 (chore: upgrade requirements)
     # via edx-opaque-keys
 sqlparse==0.5.3
     # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -225,8 +225,6 @@ pluggy==1.6.0
     #   pytest
     #   pytest-cov
     #   tox
-pycodestyle==2.14.0
-    # via -r requirements/quality.txt
 pycparser==2.23
     # via
     #   -r requirements/quality.txt

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -4,8 +4,6 @@
 -r test.txt               # Core and testing dependencies for this package
 
 edx-lint                  # edX pylint rules and plugins
-isort                     # to standardize order of imports
-pycodestyle               # PEP 8 compliance validation
 twine                     # Utility for publishing Python packages on PyPI.
 mypy                      # Static type checker
 ruff                      # A modern Python code linter and formatter.

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -134,8 +134,6 @@ pluggy==1.6.0
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
-pycodestyle==2.14.0
-    # via -r requirements/quality.in
 pycparser==2.23
     # via cffi
 pygments==2.19.2

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,9 +1,392 @@
 [lint]
 select = [
     "D", # pydocstyle
+    "E", # pycodestyle
+    "I", # isort
+]
+
+extend-select = [
+    # "PLC0104",  # disallowed-name
+    # "PLC0105",  # typevar-name-incorrect-variance
+    "D419", # empty-docstring
+    # "PLC0114",  # missing-module-docstring
+    # "PLC0115",  # missing-class-docstring
+    # "PLC0116",  # missing-function-docstring
+    "SIM208", # unnecessary-negation
+    "E711", # singleton-comparison
+    "E712", # singleton-comparison
+    "E721", # unidiomatic-typecheck
+    # "PLC0131",  # typevar-double-variance
+    # "PLC0132",  # typevar-name-mismatch
+    # "PLC0200",  # consider-using-enumerate
+    "SIM118", # consider-iterating-dictionary
+    "N804", # bad-classmethod-argument
+    # "PLC0203",  # bad-mcs-method-argument
+    # "PLC0204",  # bad-mcs-classmethod-argument
+    # "PLC0205",  # single-string-used-for-slots
+    # "PLC0206",  # consider-using-dict-items
+    # "PLC0208",  # use-sequence-for-iteration
+    "E501", # line-too-long
+    "W291", # trailing-whitespace
+    "W292", # missing-final-newline
+    "W391", # trailing-newlines
+    "E701", # multiple-statements
+    "E702", # multiple-statements
+    # "PLC0325",  # superfluous-parens
+    # "PLC0327",  # mixed-line-endings
+    # "PLC0328",  # unexpected-line-ending-format
+    # "PLC0401",  # wrong-spelling-in-comment
+    # "PLC0402",  # wrong-spelling-in-docstring
+    # "PLC0403",  # invalid-characters-in-docstring
+    "E401", # multiple-imports
+    "I001", # wrong-import-order
+    "E402", # wrong-import-position
+    "PLC0414", # useless-import-alias
+    # "PLC0415",  # import-outside-toplevel
+    # "PLC1802",  # use-implicit-booleaness-not-len
+    # "PLC1803",  # use-implicit-booleaness-not-comparison
+    "PLC2401", # non-ascii-name
+    # "PLC2403",  # non-ascii-module-import
+    # "PLC2503",  # bad-file-encoding
+    "PLC2801", # unnecessary-dunder-call
+    # "PLC3001",  # unnecessary-lambda-assignment
+    "PLC3002", # unnecessary-direct-lambda-call
+    # "PLC7620",  # simplifiable-range (Doesn't exist)
+    # "PLC7630",  # literal-used-as-attribute (Doesn't exist)
+    "S506", # unsafe-yaml-load
+    # "PLC7690",  # wrong-assert-type (Doesn't exist)
+    # "PLE0011",  # unrecognized-inline-option
+    # "PLE0013",  # bad-plugin-value
+    # "PLE0014",  # bad-configuration-section
+    # "PLE0015",  # unrecognized-option
+    "PLE0100",  # init-is-generator
+    "PLE0101", # return-in-init
+    "F811", # function-redefined
+    "F701", # not-in-loop
+    "F702", # not-in-loop
+    "F706", # return-outside-function
+    "F704", # yield-outside-function
+    "B002", # nonexistent-operator
+    # "PLE0108",  # duplicate-argument-name (not will be implemented)
+    # "PLE0110",  # abstract-class-instantiated
+    # "PLE0111",  # bad-reversed-sequence
+    # "PLE0112",  # too-many-star-expressions
+    # "PLE0113",  # invalid-star-assignment-target
+    # "PLE0114",  # star-needs-assignment-target
+    "PLE0115", # nonlocal-and-global
+    "PLE0116", # continue-in-finally
+    "PLE0117", # nonlocal-without-binding
+    # "PLE0118",  # used-prior-global-declaration
+    # "PLE0119",  # misplaced-format-function
+    # "PLE0202",  # method-hidden
+    # "PLE0203",  # access-member-before-definition
+    # "PLE0211",  # no-method-argument
+    "N805", # no-self-argument
+    # "PLE0236",  # invalid-slots-object
+    "PLE0237",  # assigning-non-slot
+    # "PLE0238",  # invalid-slots
+    # "PLE0239",  # inherit-non-class
+    # "PLE0240",  # inconsistent-mro
+    "PLE0241", # duplicate-bases
+    # "PLE0242",  # class-variable-slots-conflict
+    # "PLE0243",  # invalid-class-object
+    # "PLE0244",  # invalid-enum-extension
+    # "PLE0245",  # declare-non-slot
+    # "PLE0301",  # non-iterator-returned
+    "PLE0302", # unexpected-special-method-signature
+    "PLE0303",  # invalid-length-returned
+    # "PLE0304",  # invalid-bool-returned
+    # "PLE0305",  # invalid-index-returned
+    # "PLE0306",  # invalid-repr-returned
+    # "PLE0307",  # invalid-str-returned
+    # "PLE0308",  # invalid-bytes-returned
+    # "PLE0309",  # invalid-hash-returned
+    # "PLE0310",  # invalid-length-hint-returned
+    # "PLE0311",  # invalid-format-returned
+    # "PLE0312",  # invalid-getnewargs-returned
+    # "PLE0313",  # invalid-getnewargs-ex-returned
+    # "PLE0401",  # import-error
+    # "PLE0402",  # relative-beyond-top-level
+    "F821", # used-before-assignment
+    "F821", # undefined-variable
+    "F822", # undefined-all-variable
+    "PLE0604", # invalid-all-object
+    "PLE0605", # invalid-all-format
+    # "PLE0606",  # possibly-used-before-assignment
+    # "PLE0611",  # no-name-in-module
+    # "PLE0633",  # unpacking-non-sequence
+    "PLE0643", # potential-index-error
+    # "PLE0701",  # bad-except-order
+    # "PLE0702",  # raising-bad-type
+    "PLE0704", # misplaced-bare-raise
+    # "PLE0705",  # bad-exception-cause
+    # "PLE0710",  # raising-non-exception
+    # "PLE0711",  # notimplemented-raised
+    # "PLE0712",  # catching-non-exception
+    # "PLE1003",  # bad-super-call (not will be implemented)
+    # "PLE1101",  # no-member
+    # "PLE1102",  # not-callable
+    # "PLE1111",  # assignment-from-no-return
+    # "PLE1120",  # no-value-for-parameter
+    # "PLE1121",  # too-many-function-args
+    # "PLE1123",  # unexpected-keyword-arg
+    # "PLE1124",  # redundant-keyword-arg
+    # "PLE1125",  # missing-kwoa
+    # "PLE1126",  # invalid-sequence-index
+    # "PLE1127",  # invalid-slice-index
+    # "PLE1128",  # assignment-from-none
+    # "PLE1129",  # not-context-manager
+    # "PLE1130",  # invalid-unary-operand-type
+    # "PLE1131",  # unsupported-binary-operation
+    "PLE1132",  # repeated-keyword
+    # "PLE1133",  # not-an-iterable
+    # "PLE1134",  # not-a-mapping
+    # "PLE1135",  # unsupported-membership-test
+    # "PLE1136",  # unsubscriptable-object
+    # "PLE1137",  # unsupported-assignment-operation
+    # "PLE1138",  # unsupported-delete-operation
+    # "PLE1139",  # invalid-metaclass
+    "PLE1141", # dict-iter-missing-items
+    "PLE1142", # await-outside-async
+    # "PLE1143",  # unhashable-member
+    # "PLE1144",  # invalid-slice-step
+    # "PLE1200",  # logging-unsupported-format
+    # "PLE1201",  # logging-format-truncated
+    "PLE1205", # logging-too-many-args
+    "PLE1206", # logging-too-few-args
+    "PLE1300",  # bad-format-character
+    "F501", # truncated-format-string
+    # "PLE1302",  # mixed-format-string
+    "F502", # format-needs-mapping
+    "F524", # missing-format-string-key
+    "F522", # too-many-format-args
+    "F524", # too-few-format-args
+    "PLE1307", # bad-string-format-type
+    "PLE1310", # bad-str-strip-call
+    "PLE1507", # invalid-envvar-value
+    "PLE1519", # singledispatch-method
+    "PLE1520", # singledispatchmethod-function
+    # "PLE1700",  # yield-inside-async-function
+    # "PLE1701",  # not-async-context-manager
+    # "PLE2501",  # invalid-unicode-codec
+    "PLE2502", # bidirectional-unicode
+    "PLE2510", # invalid-character-backspace
+    # "PLE2511",  # invalid-character-carriage-return
+    "PLE2512", # invalid-character-sub
+    "PLE2513", # invalid-character-esc
+    "PLE2514", # invalid-character-nul
+    "PLE2515", # invalid-character-zero-width-space
+    # "PLE3102",  # positional-only-arguments-expected
+    # "PLE3701",  # invalid-field-call
+    # "PLE4702",  # modified-iterating-dict
+    "PLE4703", # modified-iterating-set
+    # "PLE7601",  # super-method-not-called (Doesn't exist)
+    # "PLE7602",  # non-parent-method-called
+    # "PLE7603",  # test-inherits-tests (Doesn't exist)
+    # "PLE7610",  # translation-of-non-string (Doesn't exist)
+    # "PLE7650",  # annotation-invalid-choice
+    # "PLE7651",  # annotation-duplicate-choice-value
+    # "PLE7652",  # annotation-missing-choice-value
+    # "PLE7653",  # annotation-invalid-token
+    # "PLE7654",  # annotation-duplicate-token
+    # "PLE7655",  # annotation-missing-token
+    # "PLE7660",  # toggle-no-name
+    # "PLE7661",  # toggle-empty-description
+    # "PLE7662",  # toggle-missing-target-removal-date
+    # "PLE7663",  # toggle-non-boolean-default-value
+    # "PLE7664",  # toggle-missing-annotation
+    # "PLE7665",  # invalid-django-waffle-import
+    # "PLE7670",  # setting-boolean-default-value
+    # "PLE7691",  # filter-docstring-missing-purpose
+    # "PLE7693",  # filter-docstring-missing-or-incorrect-type
+    # "PLE7694",  # filter-docstring-missing-trigger
+    # "PLF0001",  # fatal
+    # "PLF0002",  # astroid-error
+    # "PLF0010",  # parse-error
+    # "PLF0011",  # config-parse-error
+    # "PLF0202",  # method-check-failed
+    # "PLI0001",  # raw-checker-failed
+    # "PLI0010",  # bad-inline-option (Only for Pylint)
+    # "PLI0021",  # useless-suppression (Only for Pylint)
+    # "PLI0022",  # deprecated-pragma (Only for Pylint)
+    # "PLI1101",  # c-extension-no-member
+    # "PLR0022",  # useless-option-value (Only for Pylint)
+    # "PLR0123",  # literal-comparison
+    "PLR0124", # comparison-with-itself
+    # "PLR0133",  # comparison-of-constants
+    "PLR0202", # no-classmethod-decorator
+    "PLR0203", # no-staticmethod-decorator
+    "UP004",   # useless-object-inheritance
+    "PLR0206", # property-with-parameters
+    # "PLR0401",  # cyclic-import
+    # "PLR0402",  # consider-using-from-import
+    "PLR0915", # too-many-statements
+    "PLR0916", # too-many-boolean-expressions
+    "PLR0917", # too-many-positional-arguments
+    # "PLR1701",  # consider-merging-isinstance
+    "PLR1702", # too-many-nested-blocks
+    "SIM108", # simplifiable-if-statement
+    "PLR1704", # redefined-argument-from-local
+    # "PLR1706",  # consider-using-ternary
+    # "PLR1707",  # trailing-comma-tuple
+    # "PLR1708",  # stop-iteration-return
+    # "PLR1709",  # simplify-boolean-expression
+    # "PLR1710",  # inconsistent-return-statements
+    "PLR1711", # useless-return
+    # "PLR1712",  # consider-swap-variables
+    # "PLR1713",  # consider-using-join
+    # "PLR1714",  # consider-using-in
+    # "PLR1715",  # consider-using-get
+    # "PLR1716",  # chained-comparison
+    # "PLR1717",  # consider-using-dict-comprehension
+    # "PLR1718",  # consider-using-set-comprehension
+    # "PLR1719",  # simplifiable-if-expression
+    # "PLR1720",  # no-else-raise
+    "C416", # unnecessary-comprehension
+    # "PLR1722",  # consider-using-sys-exit
+    # "PLR1723",  # no-else-break
+    # "PLR1724",  # no-else-continue
+    # "PLR1725",  # super-with-arguments
+    # "PLR1726",  # simplifiable-condition
+    # "PLR1727",  # condition-evals-to-constant
+    # "PLR1728",  # consider-using-generator
+    # "PLR1729",  # use-a-generator
+    # "PLR1730",  # consider-using-min-builtin
+    # "PLR1731",  # consider-using-max-builtin
+    # "PLR1732",  # consider-using-with
+    "PLR1733", # unnecessary-dict-index-lookup
+    # "PLR1734",  # use-list-literal
+    # "PLR1735",  # use-dict-literal
+    "PLR1736", # unnecessary-list-index-lookup
+    # "PLR1737",  # use-yield-from
+    # "PLW0012",  # unknown-option-value (Only for Pylint)
+    # "PLW0101",  # unreachable
+    "B006", # dangerous-default-value
+    "B018", # pointless-statement
+    # "PLW0105",  # pointless-string-statement
+    "B018", # expression-not-assigned
+    "PIE790", # unnecessary-pass
+    "PLW0108", # unnecessary-lambda
+    "F601", # duplicate-key
+    "PLW0120", # useless-else-on-loop
+    "S102", # exec-used
+    "S307", # eval-used
+    # "PLW0124",  # confusing-with-statement
+    # "PLW0125",  # using-constant-test
+    # "PLW0126",  # missing-parentheses-for-call-in-test
+    "PLW0127", # self-assigning-variable
+    "PLW0128", # redeclared-assigned-name
+    "PLW0129", # assert-on-string-literal
+    "B033",    # duplicate-value
+    "PLW0131", # named-expr-without-context
+    # "PLW0133",  # pointless-exception-statement
+    # "PLW0134",  # return-in-finally
+    # "PLW0135",  # contextmanager-generator-missing-cleanup
+    # "PLW0143",  # comparison-with-callable
+    "B012", # lost-exception
+    "PLW0177", # nan-comparison
+    "F631", # assert-on-tuple
+    # "PLW0201",  # attribute-defined-outside-init
+    "PLW0211", # bad-staticmethod-argument
+    "SLF001", # protected-access
+    # "PLW0213",  # implicit-flag-alias
+    # "PLW0221",  # arguments-differ
+    # "PLW0222",  # signature-differs
+    # "PLW0223",  # abstract-method
+    # "PLW0231",  # super-init-not-called
+    # "PLW0233",  # non-parent-init-called (Doesn't exist)
+    # "PLW0236",  # invalid-overridden-method
+    # "PLW0237",  # arguments-renamed
+    # "PLW0238",  # unused-private-member
+    # "PLW0239",  # overridden-final-method
+    # "PLW0240",  # subclassed-final-class
+    # "PLW0244",  # redefined-slots-in-subclass
+    "PLW0245", # super-without-brackets
+    # "PLW0246",  # useless-parent-delegation
+    "E703", # unnecessary-semicolon
+    "F403", # wildcard-import
+    "F811", # reimported
+    "PLW0406", # import-self
+    # "PLW0407",  # preferred-module
+    "F404", # misplaced-future
+    # "PLW0416",  # shadowed-import
+    # "PLW0601",  # global-variable-undefined
+    "PLW0602", # global-variable-not-assigned
+    "PLW0604", # global-at-module-level
+    "F401",    # unused-import
+    "F841",    # unused-variable
+    "ARG001", # unused-argument
+    # "PLW0621",  # redefined-outer-name
+    "A001", # redefined-builtin
+    # "PLW0631",  # undefined-loop-variable
+    # "PLW0632",  # unbalanced-tuple-unpacking
+    "B023", # cell-var-from-loop
+    # "PLW0641",  # possibly-unused-variable
+    # "PLW0642",  # self-cls-assignment
+    # "PLW0644",  # unbalanced-dict-unpacking
+    "E722", # bare-except
+    "B014", # duplicate-except
+    # "PLW0706",  # try-except-raise
+    # "PLW0707",  # raise-missing-from
+    "PLW0711", # binary-op-exception
+    # "PLW0715",  # raising-format-tuple
+    # "PLW0716",  # wrong-exception-operation
+    "BLE001", # broad-exception-caught
+    # "PLW1113",  # keyword-arg-before-vararg
+    # "PLW1114",  # arguments-out-of-order
+    # "PLW1115",  # non-str-assignment-to-dunder-name
+    # "PLW1116",  # isinstance-second-argument-not-valid-type
+    # "PLW1117",  # kwarg-superseded-by-positional-arg
+    "G001", # logging-format-interpolation
+    "G002", # logging-not-lazy
+    # "PLW1300",  # bad-format-string-key
+    "F504", # unused-format-string-key
+    "F521", # bad-format-string
+    "F524", # missing-format-argument-key
+    "F507", # unused-format-string-argument
+    "F525", # format-combined-specification
+    # "PLW1306",  # missing-format-attribute
+    "F522", # invalid-format-index
+    # "PLW1308",  # duplicate-string-formatting-argument
+    # "PLW1309",  # f-string-without-interpolation
+    # "PLW1310",  # format-string-without-interpolation
+    # "PLW1401",  # anomalous-backslash-in-string
+    # "PLW1402",  # anomalous-unicode-escape-in-string
+    # "PLW1404",  # implicit-str-concat
+    # "PLW1405",  # inconsistent-quotes
+    # "PLW1406",  # redundant-u-string-prefix
+    "PLW1501", # bad-open-mode
+    # "PLW1503",  # redundant-unittest-assert
+    # "PLW1506",  # bad-thread-instantiation
+    "PLW1507", # shallow-copy-environ
+    "PLW1508", # invalid-envvar-default
+    "PLW1509", # subprocess-popen-preexec-fn
+    # "PLW1510",  # subprocess-run-check
+    # "PLW1515",  # forgotten-debug-statement
+    # "PLW1518",  # method-cache-max-size-none
+    "PLW2101", # useless-with-lock
+    # "PLW2301",  # unnecessary-ellipsis
+    # "PLW2402",  # non-ascii-file-name
+    # "PLW2601",  # using-f-string-in-unsupported-version
+    # "PLW2602",  # using-final-decorator-in-unsupported-version
+    # "PLW2603",  # using-exception-groups-in-unsupported-version
+    # "PLW2604",  # using-generic-type-syntax-in-unsupported-version
+    # "PLW2605",  # using-assignment-expression-in-unsupported-version
+    # "PLW2606",  # using-positional-only-args-in-unsupported-version
+    # "PLW3101",  # missing-timeout
+    "PLW3301", # nested-min-max
+    # "PLW3601",  # bad-chained-comparison
+    # "PLW4701",  # modified-iterating-list
+    # "PLW4901",  # deprecated-module
+    # "PLW4902",  # deprecated-method
+    # "PLW4903",  # deprecated-argument
+    # "PLW4904",  # deprecated-class
+    # "PLW4905",  # deprecated-decorator
+    # "PLW4906",  # deprecated-attribute
 ]
 
 ignore = [
+    # pydocstyle
     "D101", # Missing docstring in public class
     "D102", # Missing docstring in public method
     "D200", # One-line docstring should fit on one line
@@ -25,4 +408,40 @@ ignore = [
     "D413", # Missing blank line after last section
     "D414", # Section has no content
     "D415", # First line should end with a period, question mark, or exclamation point
+
+    # pylint
+    # "PLC0103",  # invalid-name
+    # "PLC0207",  # use-maxsplit-arg
+    # "PLC0209",  # consider-using-f-string
+    # "PLC0302",  # too-many-lines
+    # "PLC0412",  # ungrouped-imports
+    # "PLC1804",  # use-implicit-booleaness-not-comparison-to-string
+    # "PLC1805",  # use-implicit-booleaness-not-comparison-to-zero
+    # "PLE7640",  # feature-toggle-needs-doc
+    # "PLE7641",  # illegal-waffle-usage
+    # "PLI0011",  # locally-disabled
+    # "PLI0013",  # file-ignored
+    # "PLI0020",  # suppressed-message
+    # "PLI0023",  # use-symbolic-message-instead
+    # "PLR0801",  # duplicate-code
+    # "PLR0901",  # too-many-ancestors
+    # "PLR0902",  # too-many-instance-attributes
+    # "PLR0903",  # too-few-public-methods
+    "PLR0904", # too-many-public-methods
+    "PLR0911", # too-many-return-statements
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "PLR0914", # too-many-locals
+    # "PLR1705",  # no-else-return
+    # "PLW0311",  # bad-indentation
+    # "PLW0511",  # fixme
+    "PLW0603", # global-statement
+    # "PLW0614",  # unused-wildcard-import
+    # "PLW0719",  # broad-exception-raised
+    # "PLW1203",  # logging-fstring-interpolation
+    "PLW1514", # unspecified-encoding
 ]
+
+[lint.pycodestyle]
+max-line-length = 120
+max-doc-length = 120

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,6 @@
 [lint]
+preview = true
+
 select = [
     "D", # pydocstyle
     "E", # pycodestyle
@@ -6,60 +8,37 @@ select = [
 ]
 
 extend-select = [
-    # "PLC0104",  # disallowed-name
-    # "PLC0105",  # typevar-name-incorrect-variance
+    # pylint
+    "PLC0105", # typevar-name-incorrect-variance
     "D419", # empty-docstring
-    # "PLC0114",  # missing-module-docstring
-    # "PLC0115",  # missing-class-docstring
-    # "PLC0116",  # missing-function-docstring
     "SIM208", # unnecessary-negation
     "E711", # singleton-comparison
     "E712", # singleton-comparison
     "E721", # unidiomatic-typecheck
-    # "PLC0131",  # typevar-double-variance
-    # "PLC0132",  # typevar-name-mismatch
-    # "PLC0200",  # consider-using-enumerate
+    "PLC0131", # typevar-double-variance
+    "PLC0132", # typevar-name-mismatch
     "SIM118", # consider-iterating-dictionary
     "N804", # bad-classmethod-argument
-    # "PLC0203",  # bad-mcs-method-argument
-    # "PLC0204",  # bad-mcs-classmethod-argument
-    # "PLC0205",  # single-string-used-for-slots
-    # "PLC0206",  # consider-using-dict-items
-    # "PLC0208",  # use-sequence-for-iteration
+    "PLC0206", # consider-using-dict-items
+    "PLC0208", # use-sequence-for-iteration
     "E501", # line-too-long
     "W291", # trailing-whitespace
     "W292", # missing-final-newline
     "W391", # trailing-newlines
     "E701", # multiple-statements
     "E702", # multiple-statements
-    # "PLC0325",  # superfluous-parens
-    # "PLC0327",  # mixed-line-endings
-    # "PLC0328",  # unexpected-line-ending-format
-    # "PLC0401",  # wrong-spelling-in-comment
-    # "PLC0402",  # wrong-spelling-in-docstring
-    # "PLC0403",  # invalid-characters-in-docstring
     "E401", # multiple-imports
     "I001", # wrong-import-order
     "E402", # wrong-import-position
     "PLC0414", # useless-import-alias
-    # "PLC0415",  # import-outside-toplevel
-    # "PLC1802",  # use-implicit-booleaness-not-len
-    # "PLC1803",  # use-implicit-booleaness-not-comparison
+    "PLC1802", # use-implicit-booleaness-not-len
     "PLC2401", # non-ascii-name
-    # "PLC2403",  # non-ascii-module-import
-    # "PLC2503",  # bad-file-encoding
+    "PLC2403", # non-ascii-module-import
     "PLC2801", # unnecessary-dunder-call
-    # "PLC3001",  # unnecessary-lambda-assignment
+    "E731", # unnecessary-lambda-assignment
     "PLC3002", # unnecessary-direct-lambda-call
-    # "PLC7620",  # simplifiable-range (Doesn't exist)
-    # "PLC7630",  # literal-used-as-attribute (Doesn't exist)
     "S506", # unsafe-yaml-load
-    # "PLC7690",  # wrong-assert-type (Doesn't exist)
-    # "PLE0011",  # unrecognized-inline-option
-    # "PLE0013",  # bad-plugin-value
-    # "PLE0014",  # bad-configuration-section
-    # "PLE0015",  # unrecognized-option
-    "PLE0100",  # init-is-generator
+    "PLE0100", # init-is-generator
     "PLE0101", # return-in-init
     "F811", # function-redefined
     "F701", # not-in-loop
@@ -67,97 +46,34 @@ extend-select = [
     "F706", # return-outside-function
     "F704", # yield-outside-function
     "B002", # nonexistent-operator
-    # "PLE0108",  # duplicate-argument-name (not will be implemented)
-    # "PLE0110",  # abstract-class-instantiated
-    # "PLE0111",  # bad-reversed-sequence
-    # "PLE0112",  # too-many-star-expressions
-    # "PLE0113",  # invalid-star-assignment-target
-    # "PLE0114",  # star-needs-assignment-target
     "PLE0115", # nonlocal-and-global
     "PLE0116", # continue-in-finally
     "PLE0117", # nonlocal-without-binding
-    # "PLE0118",  # used-prior-global-declaration
-    # "PLE0119",  # misplaced-format-function
-    # "PLE0202",  # method-hidden
-    # "PLE0203",  # access-member-before-definition
-    # "PLE0211",  # no-method-argument
+    "PLE0118", # used-prior-global-declaration
     "N805", # no-self-argument
-    # "PLE0236",  # invalid-slots-object
-    "PLE0237",  # assigning-non-slot
-    # "PLE0238",  # invalid-slots
-    # "PLE0239",  # inherit-non-class
-    # "PLE0240",  # inconsistent-mro
+    "PLE0237", # assigning-non-slot
     "PLE0241", # duplicate-bases
-    # "PLE0242",  # class-variable-slots-conflict
-    # "PLE0243",  # invalid-class-object
-    # "PLE0244",  # invalid-enum-extension
-    # "PLE0245",  # declare-non-slot
-    # "PLE0301",  # non-iterator-returned
     "PLE0302", # unexpected-special-method-signature
-    "PLE0303",  # invalid-length-returned
-    # "PLE0304",  # invalid-bool-returned
-    # "PLE0305",  # invalid-index-returned
-    # "PLE0306",  # invalid-repr-returned
-    # "PLE0307",  # invalid-str-returned
-    # "PLE0308",  # invalid-bytes-returned
-    # "PLE0309",  # invalid-hash-returned
-    # "PLE0310",  # invalid-length-hint-returned
-    # "PLE0311",  # invalid-format-returned
-    # "PLE0312",  # invalid-getnewargs-returned
-    # "PLE0313",  # invalid-getnewargs-ex-returned
-    # "PLE0401",  # import-error
-    # "PLE0402",  # relative-beyond-top-level
+    "PLE0303", # invalid-length-returned
+    "PLE0304", # invalid-bool-returned
+    "PLE0308", # invalid-bytes-returned
+    "PLE0309", # invalid-hash-returned
     "F821", # used-before-assignment
     "F821", # undefined-variable
     "F822", # undefined-all-variable
     "PLE0604", # invalid-all-object
     "PLE0605", # invalid-all-format
-    # "PLE0606",  # possibly-used-before-assignment
-    # "PLE0611",  # no-name-in-module
-    # "PLE0633",  # unpacking-non-sequence
     "PLE0643", # potential-index-error
-    # "PLE0701",  # bad-except-order
-    # "PLE0702",  # raising-bad-type
     "PLE0704", # misplaced-bare-raise
-    # "PLE0705",  # bad-exception-cause
-    # "PLE0710",  # raising-non-exception
-    # "PLE0711",  # notimplemented-raised
-    # "PLE0712",  # catching-non-exception
-    # "PLE1003",  # bad-super-call (not will be implemented)
-    # "PLE1101",  # no-member
-    # "PLE1102",  # not-callable
-    # "PLE1111",  # assignment-from-no-return
-    # "PLE1120",  # no-value-for-parameter
-    # "PLE1121",  # too-many-function-args
-    # "PLE1123",  # unexpected-keyword-arg
-    # "PLE1124",  # redundant-keyword-arg
-    # "PLE1125",  # missing-kwoa
-    # "PLE1126",  # invalid-sequence-index
-    # "PLE1127",  # invalid-slice-index
-    # "PLE1128",  # assignment-from-none
-    # "PLE1129",  # not-context-manager
-    # "PLE1130",  # invalid-unary-operand-type
-    # "PLE1131",  # unsupported-binary-operation
-    "PLE1132",  # repeated-keyword
-    # "PLE1133",  # not-an-iterable
-    # "PLE1134",  # not-a-mapping
-    # "PLE1135",  # unsupported-membership-test
-    # "PLE1136",  # unsubscriptable-object
-    # "PLE1137",  # unsupported-assignment-operation
-    # "PLE1138",  # unsupported-delete-operation
-    # "PLE1139",  # invalid-metaclass
+    "PLE1132", # repeated-keyword
     "PLE1141", # dict-iter-missing-items
     "PLE1142", # await-outside-async
-    # "PLE1143",  # unhashable-member
-    # "PLE1144",  # invalid-slice-step
-    # "PLE1200",  # logging-unsupported-format
-    # "PLE1201",  # logging-format-truncated
     "PLE1205", # logging-too-many-args
     "PLE1206", # logging-too-few-args
-    "PLE1300",  # bad-format-character
+    "PLE1300", # bad-format-character
     "F501", # truncated-format-string
-    # "PLE1302",  # mixed-format-string
     "F502", # format-needs-mapping
+    "F506", # mixed-format-string
     "F524", # missing-format-string-key
     "F522", # too-many-format-args
     "F524", # too-few-format-args
@@ -166,104 +82,31 @@ extend-select = [
     "PLE1507", # invalid-envvar-value
     "PLE1519", # singledispatch-method
     "PLE1520", # singledispatchmethod-function
-    # "PLE1700",  # yield-inside-async-function
-    # "PLE1701",  # not-async-context-manager
-    # "PLE2501",  # invalid-unicode-codec
+    "PLE1700", # yield-inside-async-function
     "PLE2502", # bidirectional-unicode
     "PLE2510", # invalid-character-backspace
-    # "PLE2511",  # invalid-character-carriage-return
     "PLE2512", # invalid-character-sub
     "PLE2513", # invalid-character-esc
     "PLE2514", # invalid-character-nul
     "PLE2515", # invalid-character-zero-width-space
-    # "PLE3102",  # positional-only-arguments-expected
-    # "PLE3701",  # invalid-field-call
-    # "PLE4702",  # modified-iterating-dict
     "PLE4703", # modified-iterating-set
-    # "PLE7601",  # super-method-not-called (Doesn't exist)
-    # "PLE7602",  # non-parent-method-called
-    # "PLE7603",  # test-inherits-tests (Doesn't exist)
-    # "PLE7610",  # translation-of-non-string (Doesn't exist)
-    # "PLE7650",  # annotation-invalid-choice
-    # "PLE7651",  # annotation-duplicate-choice-value
-    # "PLE7652",  # annotation-missing-choice-value
-    # "PLE7653",  # annotation-invalid-token
-    # "PLE7654",  # annotation-duplicate-token
-    # "PLE7655",  # annotation-missing-token
-    # "PLE7660",  # toggle-no-name
-    # "PLE7661",  # toggle-empty-description
-    # "PLE7662",  # toggle-missing-target-removal-date
-    # "PLE7663",  # toggle-non-boolean-default-value
-    # "PLE7664",  # toggle-missing-annotation
-    # "PLE7665",  # invalid-django-waffle-import
-    # "PLE7670",  # setting-boolean-default-value
-    # "PLE7691",  # filter-docstring-missing-purpose
-    # "PLE7693",  # filter-docstring-missing-or-incorrect-type
-    # "PLE7694",  # filter-docstring-missing-trigger
-    # "PLF0001",  # fatal
-    # "PLF0002",  # astroid-error
-    # "PLF0010",  # parse-error
-    # "PLF0011",  # config-parse-error
-    # "PLF0202",  # method-check-failed
-    # "PLI0001",  # raw-checker-failed
-    # "PLI0010",  # bad-inline-option (Only for Pylint)
-    # "PLI0021",  # useless-suppression (Only for Pylint)
-    # "PLI0022",  # deprecated-pragma (Only for Pylint)
-    # "PLI1101",  # c-extension-no-member
-    # "PLR0022",  # useless-option-value (Only for Pylint)
-    # "PLR0123",  # literal-comparison
     "PLR0124", # comparison-with-itself
-    # "PLR0133",  # comparison-of-constants
     "PLR0202", # no-classmethod-decorator
     "PLR0203", # no-staticmethod-decorator
-    "UP004",   # useless-object-inheritance
+    "UP004", # useless-object-inheritance
     "PLR0206", # property-with-parameters
-    # "PLR0401",  # cyclic-import
-    # "PLR0402",  # consider-using-from-import
     "PLR0915", # too-many-statements
     "PLR0916", # too-many-boolean-expressions
     "PLR0917", # too-many-positional-arguments
-    # "PLR1701",  # consider-merging-isinstance
     "PLR1702", # too-many-nested-blocks
     "SIM108", # simplifiable-if-statement
     "PLR1704", # redefined-argument-from-local
-    # "PLR1706",  # consider-using-ternary
-    # "PLR1707",  # trailing-comma-tuple
-    # "PLR1708",  # stop-iteration-return
-    # "PLR1709",  # simplify-boolean-expression
-    # "PLR1710",  # inconsistent-return-statements
     "PLR1711", # useless-return
-    # "PLR1712",  # consider-swap-variables
-    # "PLR1713",  # consider-using-join
-    # "PLR1714",  # consider-using-in
-    # "PLR1715",  # consider-using-get
-    # "PLR1716",  # chained-comparison
-    # "PLR1717",  # consider-using-dict-comprehension
-    # "PLR1718",  # consider-using-set-comprehension
-    # "PLR1719",  # simplifiable-if-expression
-    # "PLR1720",  # no-else-raise
     "C416", # unnecessary-comprehension
-    # "PLR1722",  # consider-using-sys-exit
-    # "PLR1723",  # no-else-break
-    # "PLR1724",  # no-else-continue
-    # "PLR1725",  # super-with-arguments
-    # "PLR1726",  # simplifiable-condition
-    # "PLR1727",  # condition-evals-to-constant
-    # "PLR1728",  # consider-using-generator
-    # "PLR1729",  # use-a-generator
-    # "PLR1730",  # consider-using-min-builtin
-    # "PLR1731",  # consider-using-max-builtin
-    # "PLR1732",  # consider-using-with
     "PLR1733", # unnecessary-dict-index-lookup
-    # "PLR1734",  # use-list-literal
-    # "PLR1735",  # use-dict-literal
     "PLR1736", # unnecessary-list-index-lookup
-    # "PLR1737",  # use-yield-from
-    # "PLW0012",  # unknown-option-value (Only for Pylint)
-    # "PLW0101",  # unreachable
     "B006", # dangerous-default-value
     "B018", # pointless-statement
-    # "PLW0105",  # pointless-string-statement
     "B018", # expression-not-assigned
     "PIE790", # unnecessary-pass
     "PLW0108", # unnecessary-lambda
@@ -271,118 +114,48 @@ extend-select = [
     "PLW0120", # useless-else-on-loop
     "S102", # exec-used
     "S307", # eval-used
-    # "PLW0124",  # confusing-with-statement
-    # "PLW0125",  # using-constant-test
-    # "PLW0126",  # missing-parentheses-for-call-in-test
     "PLW0127", # self-assigning-variable
     "PLW0128", # redeclared-assigned-name
     "PLW0129", # assert-on-string-literal
-    "B033",    # duplicate-value
+    "B033", # duplicate-value
     "PLW0131", # named-expr-without-context
-    # "PLW0133",  # pointless-exception-statement
-    # "PLW0134",  # return-in-finally
-    # "PLW0135",  # contextmanager-generator-missing-cleanup
-    # "PLW0143",  # comparison-with-callable
     "B012", # lost-exception
     "PLW0177", # nan-comparison
     "F631", # assert-on-tuple
-    # "PLW0201",  # attribute-defined-outside-init
     "PLW0211", # bad-staticmethod-argument
     "SLF001", # protected-access
-    # "PLW0213",  # implicit-flag-alias
-    # "PLW0221",  # arguments-differ
-    # "PLW0222",  # signature-differs
-    # "PLW0223",  # abstract-method
-    # "PLW0231",  # super-init-not-called
-    # "PLW0233",  # non-parent-init-called (Doesn't exist)
-    # "PLW0236",  # invalid-overridden-method
-    # "PLW0237",  # arguments-renamed
-    # "PLW0238",  # unused-private-member
-    # "PLW0239",  # overridden-final-method
-    # "PLW0240",  # subclassed-final-class
-    # "PLW0244",  # redefined-slots-in-subclass
     "PLW0245", # super-without-brackets
-    # "PLW0246",  # useless-parent-delegation
     "E703", # unnecessary-semicolon
     "F403", # wildcard-import
     "F811", # reimported
     "PLW0406", # import-self
-    # "PLW0407",  # preferred-module
     "F404", # misplaced-future
-    # "PLW0416",  # shadowed-import
-    # "PLW0601",  # global-variable-undefined
     "PLW0602", # global-variable-not-assigned
     "PLW0604", # global-at-module-level
-    "F401",    # unused-import
-    "F841",    # unused-variable
+    "F401", # unused-import
+    "F841", # unused-variable
     "ARG001", # unused-argument
-    # "PLW0621",  # redefined-outer-name
     "A001", # redefined-builtin
-    # "PLW0631",  # undefined-loop-variable
-    # "PLW0632",  # unbalanced-tuple-unpacking
     "B023", # cell-var-from-loop
-    # "PLW0641",  # possibly-unused-variable
-    # "PLW0642",  # self-cls-assignment
-    # "PLW0644",  # unbalanced-dict-unpacking
     "E722", # bare-except
     "B014", # duplicate-except
-    # "PLW0706",  # try-except-raise
-    # "PLW0707",  # raise-missing-from
     "PLW0711", # binary-op-exception
-    # "PLW0715",  # raising-format-tuple
-    # "PLW0716",  # wrong-exception-operation
     "BLE001", # broad-exception-caught
-    # "PLW1113",  # keyword-arg-before-vararg
-    # "PLW1114",  # arguments-out-of-order
-    # "PLW1115",  # non-str-assignment-to-dunder-name
-    # "PLW1116",  # isinstance-second-argument-not-valid-type
-    # "PLW1117",  # kwarg-superseded-by-positional-arg
+    "B026", # keyword-arg-before-vararg
     "G001", # logging-format-interpolation
     "G002", # logging-not-lazy
-    # "PLW1300",  # bad-format-string-key
     "F504", # unused-format-string-key
     "F521", # bad-format-string
     "F524", # missing-format-argument-key
     "F507", # unused-format-string-argument
     "F525", # format-combined-specification
-    # "PLW1306",  # missing-format-attribute
     "F522", # invalid-format-index
-    # "PLW1308",  # duplicate-string-formatting-argument
-    # "PLW1309",  # f-string-without-interpolation
-    # "PLW1310",  # format-string-without-interpolation
-    # "PLW1401",  # anomalous-backslash-in-string
-    # "PLW1402",  # anomalous-unicode-escape-in-string
-    # "PLW1404",  # implicit-str-concat
-    # "PLW1405",  # inconsistent-quotes
-    # "PLW1406",  # redundant-u-string-prefix
     "PLW1501", # bad-open-mode
-    # "PLW1503",  # redundant-unittest-assert
-    # "PLW1506",  # bad-thread-instantiation
     "PLW1507", # shallow-copy-environ
     "PLW1508", # invalid-envvar-default
     "PLW1509", # subprocess-popen-preexec-fn
-    # "PLW1510",  # subprocess-run-check
-    # "PLW1515",  # forgotten-debug-statement
-    # "PLW1518",  # method-cache-max-size-none
     "PLW2101", # useless-with-lock
-    # "PLW2301",  # unnecessary-ellipsis
-    # "PLW2402",  # non-ascii-file-name
-    # "PLW2601",  # using-f-string-in-unsupported-version
-    # "PLW2602",  # using-final-decorator-in-unsupported-version
-    # "PLW2603",  # using-exception-groups-in-unsupported-version
-    # "PLW2604",  # using-generic-type-syntax-in-unsupported-version
-    # "PLW2605",  # using-assignment-expression-in-unsupported-version
-    # "PLW2606",  # using-positional-only-args-in-unsupported-version
-    # "PLW3101",  # missing-timeout
     "PLW3301", # nested-min-max
-    # "PLW3601",  # bad-chained-comparison
-    # "PLW4701",  # modified-iterating-list
-    # "PLW4901",  # deprecated-module
-    # "PLW4902",  # deprecated-method
-    # "PLW4903",  # deprecated-argument
-    # "PLW4904",  # deprecated-class
-    # "PLW4905",  # deprecated-decorator
-    # "PLW4906",  # deprecated-attribute
 ]
 
 ignore = [
@@ -410,35 +183,22 @@ ignore = [
     "D415", # First line should end with a period, question mark, or exclamation point
 
     # pylint
-    # "PLC0103",  # invalid-name
-    # "PLC0207",  # use-maxsplit-arg
-    # "PLC0209",  # consider-using-f-string
-    # "PLC0302",  # too-many-lines
-    # "PLC0412",  # ungrouped-imports
-    # "PLC1804",  # use-implicit-booleaness-not-comparison-to-string
-    # "PLC1805",  # use-implicit-booleaness-not-comparison-to-zero
-    # "PLE7640",  # feature-toggle-needs-doc
-    # "PLE7641",  # illegal-waffle-usage
-    # "PLI0011",  # locally-disabled
-    # "PLI0013",  # file-ignored
-    # "PLI0020",  # suppressed-message
-    # "PLI0023",  # use-symbolic-message-instead
-    # "PLR0801",  # duplicate-code
-    # "PLR0901",  # too-many-ancestors
-    # "PLR0902",  # too-many-instance-attributes
-    # "PLR0903",  # too-few-public-methods
+    "N815", # invalid-name
+    "I001", # ungrouped-imports
     "PLR0904", # too-many-public-methods
     "PLR0911", # too-many-return-statements
     "PLR0912", # too-many-branches
     "PLR0913", # too-many-arguments
     "PLR0914", # too-many-locals
-    # "PLR1705",  # no-else-return
-    # "PLW0311",  # bad-indentation
-    # "PLW0511",  # fixme
+    "RET505", # no-else-return
+    "E111", # bad-indentation
+    "FIX001", # fixme
+    "FIX002", # fixme
+    "FIX003", # fixme
+    "FIX004", # fixme
     "PLW0603", # global-statement
-    # "PLW0614",  # unused-wildcard-import
-    # "PLW0719",  # broad-exception-raised
-    # "PLW1203",  # logging-fstring-interpolation
+    "TRY002", # broad-exception-raised
+    "G004", # logging-fstring-interpolation
     "PLW1514", # unspecified-encoding
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,2 @@
-[isort]
-include_trailing_comma = True
-indent = '    '
-line_length = 120
-multi_line_output = 3
-
 [wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,6 @@ envlist = py{311, 312}-django{42,52}, quality, docs
 ; D001 = Line too long
 ignore=D001
 
-[pycodestyle]
-exclude = .git,.tox
-max-line-length = 120
-max-doc-length = 120
-
 [pytest]
 DJANGO_SETTINGS_MODULE = test_utils.test_settings
 addopts = --cov openedx_filters --cov-report term-missing --cov-report xml


### PR DESCRIPTION
## Description

This PR replaces [`pycodestyle`](https://github.com/PyCQA/pycodestyle), [`isort`](https://github.com/PyCQA/isort) and [`pylint`](https://github.com/pylint-dev/pylint) _(partially)_.

## Testing instructions

You can run `make quality` in your local or see the PR checks.

## Supporting information

- https://github.com/openedx/openedx-filters/pull/270#issuecomment-2706411504
- https://discuss.openedx.org/t/pylint-and-ease-of-development/15085/7

## Deadline

None

## Other information

`pycodestyle` and `isort` can be completely replaced with `ruff` but not with `pylint`. More information in [Ruff and Pylint comparison](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-pylint)

- Ruff doesn't currently support [custom rules](https://github.com/astral-sh/ruff/issues/283), Pylint does. Open edX has some custom rules that couldn't be implemented for now.

Below is the detail of each rule. Here is an issue with the pylint rules implemented in Ruff (https://github.com/astral-sh/ruff/issues/970) In summary:

- **Total**: 173 rules
- **Implemented**: 82 rules (47.4%)
- **NOT Implemented** (❌ + custom Open edX): 74 rules (42.8%)
- **Others**: 17 rules (9.8%)

<details><summary>Rules</summary>
<p>

### Enabled Rules

#### Implemented

- `line-too-long` (E501)
- `assert-on-tuple` (F631)
- `assigning-non-slot` (PLE0237)
- `bad-format-character` (PLE1300)
- `bad-staticmethod-argument` (PLW0211)
- `bad-str-strip-call` (PLE1310)
- `bad-format-string` (F521)
- `bad-open-mode` (PLW1501)
- `binary-op-exception` (PLW0711)
- `cell-var-from-loop` (B023)
- `continue-in-finally` (PLE0116)
- `dangerous-default-value` (B006)
- `duplicate-bases` (PLE0241)
- `duplicate-except` (B014)
- `duplicate-key` (F601)
- `expression-not-assigned` (B018)
- `format-combined-specification` (F525)
- `format-needs-mapping` (F502)
- `function-redefined` (F811)
- `import-self` (PLW0406)
- `init-is-generator` (PLE0100)
- `invalid-all-object` (PLE0604)
- `invalid-format-index` (F522)
- `invalid-length-returned` (PLE0303)
- `logging-too-few-args` (PLE1206)
- `logging-too-many-args` (PL1205)
- `lost-exception` (B012)
- `misplaced-bare-raise` (PLE704)
- `misplaced-future` (F404)
- `missing-format-argument-key` (F524)
- `missing-format-string-key` (F524)
- `no-self-argument` (N805)
- `nonexistent-operator` (B002)
- `not-in-loop` (F701, F702)
- `pointless-statement` (B018)
- `redefined-builtin` (A001)
- `repeated-keyword` (PLE1132)
- `return-in-init` (PLE0101)
- `return-outside-function` (F706)
- `syntax-error` (E999) -> Always enabled
- `too-few-format-args` (F524)
- `too-many-format-args` (F522)
- `truncated-format-string` (F501)
- `undefined-all-variable` (F822)
- `undefined-variable` (F821)
- `unexpected-special-method-signature` (PLE0302)
- `unused-format-string-argument` (F507)
- `unused-format-string-key` (F504)
- `used-before-assignment` (F821)
- `yield-outside-function` (F704)
- `missing-docstring` -> Renamed to:
    - `missing-module-docstring` (D100) Enabled in pydocstyle
    - `missing-class-docstring` (D101) Disabled in pydocstyle
    - `missing-function-docstring` (D103) Enabled in pydocstyle
- `empty-docstring` (D419)
- `unused-argument` (ARG001)
- `unused-import` (F401)
- `unused-variable` (F841)
- `eval-used` (S307)
- `exec-used` (S102)
- `bad-classmethod-argument` (N804)
- `bare-except` (E722)
- `broad-except` -> Renamed to `broad-exception-caught` (BLE001)
- `consider-iterating-dictionary` (SIM118)
- `global-at-module-level` (PLW0604)
- `global-variable-not-assigned` (PLW0602)
- `logging-format-interpolation` (G001)
- `logging-not-lazy` (G002)
- `multiple-imports` (E401)
- `multiple-statements` (E701, E702)
- `no-classmethod-decorator` (PLR0202)
- `no-staticmethod-decorator` (PLR0203)
- `protected-access` (SLF001)
- `reimported` (F811)
- `simplifiable-if-statement` (SIM108)
- `singleton-comparison` (E711, E712)
- `unidiomatic-typecheck` (E721)
- `unnecessary-lambda` (PLW0108)
- `unnecessary-pass` (PIE790)
- `unnecessary-semicolon` (E703)
- `unneeded-not` -> Renamed to `unnecessary-negation` (SIM208)
- `useless-else-on-loop` (PLW0120)
- `too-many-boolean-expressions` (PLR0916)
- `too-many-nested-blocks` (PLR1702)
- `too-many-statements` (PLR0915)
- `wildcard-import` (F403)
- `wrong-import-order` (I001)
- `wrong-import-position` (E402)
- `missing-final-newline` (W292)
- `trailing-newlines` (W391)
- `trailing-whitespace` (W291)

Not explicitly mentioned in the `pylintrc` file but enabled:

- `typevar-name-incorrect-variance` (PLC0105)
- `typevar-double-variance` (PLC0131)
- `typevar-name-mismatch` (PLC0132)
- `consider-using-dict-items` (PLC0206)
- `use-sequence-for-iteration` (PLC0208)
- `useless-import-alias` (PLC0414)
- `use-implicit-booleaness-not-len` (PLC1802)
- `non-ascii-name` (PLC2401)
- `non-ascii-module-import` (PLC2403)
- `unnecessary-dunder-call` (PLC2801)
- `unnecessary-lambda-assignment` (E731)
- `unnecessary-direct-lambda-call` (PLC3002)
- `unsafe-yaml-load` (S506)
- `nonlocal-and-global` (PLE0115)
- `used-prior-global-declaration` (PLE0118)
- `invalid-bytes-returned` (PLE0308)
- `invalid-hash-returned` (PLE0309)
- `potential-index-error` (PLE0643)
- `await-outside-async` (PLE1142)
- `mixed-format-string` (F506)
- `singledispatch-method` (PLE1519)
- `singledispatchmethod-function` (PLE1520)
- `yield-inside-async-function` (PLE1700)
- `bidirectional-unicode` (PLE2502)
- `invalid-character-backspace` (PLE2510)
- `invalid-character-sub` (PLE2512)
- `invalid-character-esc` (PLE2513)
- `invalid-character-nul` (PLE2514)
- `invalid-character-zero-width-space` (PLE2515)
- `modified-iterating-set` (PLE4703)
- `keyword-arg-before-vararg` (B026)

#### NOT Implemented

- `blacklisted-name` -> Renamed to `disallowed-name` (❌)
- `abstract-class-instantiated` (❌)
- `abstract-method` (❌)
- `access-member-before-definition` (❌)
- `anomalous-backslash-in-string` (❌)
- `anomalous-unicode-escape-in-string` (❌)
- `arguments-differ` (❌)
- `assignment-from-no-return` (❌)
- `assignment-from-none` (❌)
- `attribute-defined-outside-init` (❌)
- `bad-except-order` (❌)
- `bad-format-string-key` (❌)
- `bad-reversed-sequence` (❌)
- `bad-super-call` (❌) Not will be implemented in Ruff
- `catching-non-exception` (❌)
- `confusing-with-statement` (❌)
- `duplicate-argument-name` (❌) Not will be implemented in Ruff
- `global-variable-undefined` (❌)
- `import-error` (❌)
- `inconsistent-mro` (❌)
- `inherit-non-class` (❌)
- `invalid-sequence-index` (❌)
- `invalid-slice-index` (❌)
- `invalid-slots-object` (❌)
- `invalid-slots` (❌)
- `invalid-unary-operand-type` (❌)
- `logging-unsupported-format` (❌)
- `method-hidden` (❌)
- `missing-format-attribute` (❌)
- `no-member` (❌)
- `no-method-argument` (❌)
- `no-name-in-module` (❌)
- `no-value-for-parameter` (❌)
- `non-iterator-returned` (❌)
- `not-a-mapping` (❌)
- `not-an-iterable` (❌)
- `not-callable` (❌)
- `not-context-manager` (❌)
- `pointless-string-statement` (❌)
- `raising-bad-type` (❌)
- `raising-non-exception` (❌)
- `redefined-outer-name` (❌)
- `redundant-keyword-arg` (❌)
- `signature-differs` (❌)
- `super-init-not-called` (❌)
- `too-many-function-args` (❌)
- `undefined-loop-variable` (❌)
- `unexpected-keyword-arg` (❌)
- `unpacking-non-sequence` (❌)
- `unreachable` (❌)
- `unsubscriptable-object` (❌)
- `unsupported-binary-operation` (❌)
- `unsupported-membership-test` (❌)
- `using-constant-test` (❌)
- `invalid-characters-in-docstring` (❌)
- `wrong-spelling-in-comment` (❌)
- `wrong-spelling-in-docstring` (❌)
- `bad-mcs-classmethod-argument` (❌)
- `bad-mcs-method-argument` (❌)
- `consider-using-enumerate` (❌)
- `redundant-unittest-assert` (❌)
- `superfluous-parens` (❌)
- `deprecated-method` (❌)
- `deprecated-module` (❌)
- `mixed-line-endings` (❌)
- `unexpected-line-ending-format` (❌)

Others are not explicitly mentioned in the `pylintrc` file but are enabled:

- `wrong-spelling-in-comment` (❌)
- `wrong-spelling-in-docstring` (❌)
- `use-implicit-booleaness-not-comparison` (❌)
- `bad-file-encoding` (❌)
- `misplaced-format-function` (❌)
- `class-variable-slots-conflict` (❌)
- `invalid-class-object` (❌)
- `invalid-enum-extension` (❌)
- `declare-non-slot` (❌)
- `invalid-length-hint-returned` (❌)
- `invalid-format-returned` (❌)
- `invalid-getnewargs-returned` (❌)
- `invalid-getnewargs-ex-returned` (❌)
- `dict-iter-missing-items` (❌)
- `unhashable-member` (❌)
- `invalid-slice-step` (❌)
- `logging-format-truncated` (❌)
- `invalid-envvar-value` (❌)
- `not-async-context-manager` (❌)
- `invalid-unicode-codec` (❌)
- `invalid-character-carriage-return` (❌)
- `positional-only-arguments-expected` (❌)
- `invalid-field-call` (❌)
- `modified-iterating-dict` (❌)
- `raising-format-tuple` (❌)
- `wrong-exception-operation` (❌)
- `arguments-out-of-order` (❌)

### Disabled Rules

#### Implemented

- `invalid-name` (N815)
- `ungrouped-imports` (I001)
- `too-many-public-methods` (PLR0904)
- `too-many-return-statements` (PLR0911)
- `too-many-branches` (PLR0912)
- `too-many-arguments` (PLR0913)
- `too-many-locals` (PLR0914)
- `no-else-return` (RET505)
- `bad-indentation` (E111)
- `fixme` (FIX001, FIX002, FIX003, FIX004)
- `global-statement` (PLW0603)
- `broad-exception-raised` (TRY002)
- `logging-fstring-interpolation` (G004)
- `unspecified-encoding` (PLW1514)

#### NOT Implemented

- `use-maxsplit-arg` (❌)
- `invalid-name` (❌)
- `use-maxsplit-arg` (❌)
- `consider-using-f-string` (❌)
- `too-many-lines` (❌) Not compatible with the Ruff Formatter
- `use-implicit-booleaness-not-comparison-to-string` (❌) Not will be implemented in Ruff
- `use-implicit-booleaness-not-comparison-to-zero` (❌) Not will be implemented in Ruff
- `duplicate-code` (❌)
- `too-many-ancestors` (❌)
- `too-many-instance-attributes` (❌)
- `too-few-public-methods` (❌)
- `unused-wildcard-import` (❌)


These are Open edX custom rules that could not be implemented in Ruff because it does not have support for it yet 

#### Enabled

- `non-parent-method-called`
- `super-method-not-called`
- `test-inherits-tests`
- `translation-of-non-string`
- `literal-used-as-attribute`
- `simplifiable-range`
- `wrong-assert-type`
- `toggle-no-name`
- `toggle-empty-description`
- `toggle-missing-target-removal-date`
- `toggle-non-boolean-default-value`
- `toggle-missing-annotation`
- `invalid-django-waffle-import`
- `setting-boolean-default-value`
- `filter-docstring-missing-purpose`
- `filter-docstring-missing-or-incorrect-type`
- `filter-docstring-missing-trigger`

#### Disabled

- `feature-toggle-needs-doc`
- `illegal-waffle-usage`

These are rules that were not referenced in Pylint, nor as an Open edX Custom Rule (although they appear to be custom, but may have been removed)  

#### Enabled

- `annotation-invalid-choice`
- `annotation-duplicate-choice-value`
- `annotation-missing-choice-value`
- `annotation-invalid-token`
- `annotation-duplicate-token`
- `annotation-missing-token`

These are the rules that are specific to Pylint and are not required in Ruff

- `astroid-error`
- `fatal`
- `method-check-failed`
- `parse-error`
- `raw-checker-failed`
- `bad-inline-option`
- `bad-option-value` -> Renamed to:
    - `useless-option-value`
    - `unknown-option-value`
- `deprecated-pragma`
- `unrecognized-inline-option`
- `useless-suppression`
- `locally-disabled`
- `file-ignored`
- `suppressed-message`
- `use-symbolic-message-instead`
- `bad-configuration-section`
- `config-parse-error`

And finally, these are the rules that would no longer be required by the Python version

- `return-arg-in-generator` (⚠️) Not necessary for Python 3.3+
- `boolean-datetime` (⚠️) Fixed in Python 3.5
</p>
</details> 

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Changelog entry added using scriv with a short description of the change
- [ ] Documentation updated (not only docstrings)
- [ ] Code dependencies reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Trigger the release workflow to create a new GitHub release.
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
