### PR TITLE
chore: fix python ci status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,8 +110,8 @@ Please do not report security issues in public. Please email security@openedx.or
     :target: https://pypi.python.org/pypi/openedx-filters/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/openedx/openedx-filters/workflows/Python%20CI/badge.svg?branch=main
-    :target: https://github.com/openedx/openedx-filters/actions
+.. |ci-badge| image:: https://github.com/openedx/openedx-filters/actions/workflows/ci.yml/badge.svg?branch=main
+    :target: https://github.com/openedx/openedx-filters/actions/workflows/ci.yml
     :alt: CI
 
 .. |codecov-badge| image:: https://codecov.io/github/openedx/openedx-filters/coverage.svg?branch=main


### PR DESCRIPTION
## Description

This PR fixes the Python CI status badge in the README. The badge was generated in **Actions > Python CI > [•••] > Create status badge**

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/38af7e12-77a3-4c79-a02c-b557e7e89a50)

### After
![image](https://github.com/user-attachments/assets/971d3c96-df27-4497-8ea8-8eb2197871f0)

## Deadline

None

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Changelog entry added using scriv with short description of the change
- [ ] Documentation updated (not only docstrings)
- [ ] Code dependencies reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Trigger the release workflow to create a new GitHub release.
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
