### PR TITLE
chore: Add references to docs to make relative, not direct, references

### DIFF
--- a/docs/decisions/index.rst
+++ b/docs/decisions/index.rst
@@ -1,3 +1,5 @@
+.. _ADRs:
+
 Decisions
 =========
 


### PR DESCRIPTION
Usage of `:doc:` is an antipattern. It is fragile and prone to breaking cross references when docs are moved or renamed.

Adding in `.. _reference:` syntax to files and headings means cross-references can instead be made with the `:ref:` directive, which will (presuming the references themselves are not deleted or renamed) be more robust to docs refactorings.
