### PR TITLE
docs: replace events references with filters in arch subdomain docs

### DIFF
--- a/docs/reference/architecture-subdomains.rst
+++ b/docs/reference/architecture-subdomains.rst
@@ -1,9 +1,9 @@
 .. _Architecture Subdomains Reference:
 
 Architecture Subdomains
-########################
+#######################
 
-Currently, these are the `architecture subdomains`_ used by the Open edX Events library:
+Currently, these are the `architecture subdomains`_ used by the Open edX Filters library:
 
 +-------------------+----------------------------------------------------------------------------------------------------+
 | Subdomain Name    | Description                                                                                        |
@@ -12,24 +12,19 @@ Currently, these are the `architecture subdomains`_ used by the Open edX Events 
 +-------------------+----------------------------------------------------------------------------------------------------+
 | Learning          | Allows learners to consume content and perform actions in a learning activity on the platform.     |
 +-------------------+----------------------------------------------------------------------------------------------------+
-| Analytics         | Provides visibility into learner behavior and course performance.                                  |
-+-------------------+----------------------------------------------------------------------------------------------------+
-| Enterprise        | Provides tools for organizations to manage their learners and courses.                             |
-+-------------------+----------------------------------------------------------------------------------------------------+
 
-Here we list useful information about Open edX :term:`architecture subdomains` and their use in the Hooks Extension framework:
+Here we list useful information about Open edX architecture subdomains and their use in the Hooks Extension framework:
 
-- `Events Naming and Versioning`_
-- `Notes on events design and subdomains`_
+- :ref:`Filters Naming and Versioning <ADR-4>`
 - `edX Domain Driven Design documentation`_
-- :ref:`Subdomains from OEP-41 <open-edx-proposals:Subdomain from DDD>`
-- :ref:`open-edx-proposals:Message Content Data Guidelines`
+- `Subdomains from OEP-41`_
+- `Message Content Data Guidelines`_
 
 .. note:: When creating new filters in a new subdomain, please list the subdomain in this document and in :ref:`Existing Filters`.
 
-.. _Events Naming and Versioning: https://github.com/openedx/openedx-events/blob/main/docs/decisions/0002-events-naming-and-versioning.rst#L1
 .. _edX Domain Driven Design documentation: https://openedx.atlassian.net/wiki/spaces/AC/pages/213910332/Domain-Driven+Design
-.. _`Notes on events design and subdomains`: https://github.com/openedx/openedx-events/issues/72#issuecomment-1179291340
+.. _Subdomains from OEP-41: https://docs.openedx.org/projects/openedx-proposals/en/latest/architectural-decisions/oep-0041-arch-async-server-event-messaging.html#subdomain-from-domain-driven-design
+.. _Message Content Data Guidelines: https://docs.openedx.org/projects/openedx-proposals/en/latest/architectural-decisions/oep-0041-arch-async-server-event-messaging.html?highlight=subdomain#message-content-data-guidelines
 .. _architecture subdomains: https://microservices.io/patterns/decomposition/decompose-by-subdomain.html
 
 **Maintenance chart**


### PR DESCRIPTION
## Description

This PR updates the [Architecture Subdomain Documentation](https://docs.openedx.org/projects/openedx-filters/en/latest/reference/architecture-subdomains.html) to replace all event references with filter references.

## Testing instructions

Check the updated documentation here.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Changelog entry added using scriv with short description of the change
- [ ] Documentation updated (not only docstrings)
- [ ] Code dependencies reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Trigger the release workflow to create a new GitHub release.
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
