### PR TITLE
feat: add CoursewareViewStarted, CourseStartDateValidationFailed, and CoursewareAccessChecksRequested filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,15 +33,26 @@ Unreleased
 ----------
 .. scriv-insert-here
 
+.. _changelog-3.5.0:
+
+[v3.5.0] - 2026-06-02
+---------------------
+
+Added
+~~~~~
+
+* Added ``CoursewareViewStarted``, ``CourseStartDateValidationFailed``, and ``CoursewareAccessChecksRequested`` filters to the learning subdomain.
+
 [3.4.1] - 2026-05-26
+--------------------
 
 Changed
-~~~~~
+~~~~~~~
 
 * Update ``InstructorDashboardTabsRequested`` to match ``run_filter`` return pattern of other filters. by @holaontiveros
 
-
 [3.4.0] - 2026-05-07
+--------------------
 
 Added
 ~~~~~
@@ -53,7 +64,7 @@ Added
 See the fragment files in the `changelog.d directory`_.
 .. _changelog.d directory: https://github.com/openedx/openedx-filters/tree/master/changelog.d
 
-[3.3.0] - 2025-04-17
+[3.3.0] - 2026-04-17
 --------------------
 
 Changed
@@ -61,7 +72,7 @@ Changed
 
 * Expand Python version compatibility
 
-[3.2.0] - 2025-04-13
+[3.2.0] - 2026-04-13
 --------------------
 
 Changed
@@ -69,7 +80,7 @@ Changed
 
 * Added GradeEventContextRequested filter
 
-[3.1.0] - 2025-04-06
+[3.1.0] - 2026-04-06
 --------------------
 
 Changed
@@ -77,13 +88,38 @@ Changed
 
 * Added AccountSettingsReadOnlyFieldsRequested filter
 
-[3.0.0] - 2025-03-19
+[3.0.0] - 2026-03-19
 --------------------
 
 Changed
 ~~~~~~~
 
 * Dropped Python 3.11 support
+
+[2.1.0] - 2025-04-28
+--------------------
+
+Added
+~~~~~
+
+* New documentation section with naming suggestions for creating filters. (by @mariajgrimaldi)
+
+* Migrate to ``scriv`` for manage changelog. (by @bryanttv)
+
+Changed
+~~~~~~~
+
+* Updated documentation titles and styles to follow the Open edX style guide. (by @Apgomeznext)
+
+* Updated the glossary section in the documentation. (by @Apgomeznext)
+
+* Improved how-to guides including updates to filters, samples, and formatting. (by @mariajgrimaldi)
+
+* Updated edX RTD link to Open edX RTD. (by @sarina)
+
+* Replaced the deprecated ``pydocstyle`` library with ``ruff``. (by @bryanttv)
+
+* Improved documentation of filter configuration including details on configuration formats. (by @bryanttv)
 
 [2.0.1] - 2025-02-18
 --------------------

--- a/changelog.d/20250326_102750_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_102750_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Added
-~~~~~
-* New documentation section with naming suggestions for creating filters. (by @mariajgrimaldi)

--- a/changelog.d/20250326_103610_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_103610_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Changed
-~~~~~~~
-* Updated documentation titles and styles to follow the Open edX style guide. (by @Apgomeznext)

--- a/changelog.d/20250326_104004_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_104004_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Changed
-~~~~~~~
-* Updated the glossary section in the documentation. (by @Apgomeznext)

--- a/changelog.d/20250326_104238_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_104238_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Changed
-~~~~~~~
-* Improved how-to guides including updates to filters, samples, and formatting. (by @mariajgrimaldi)

--- a/changelog.d/20250326_110813_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_110813_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Changed
-~~~~~~~
-* Updated edX RTD link to Open edX RTD. (by @sarina)

--- a/changelog.d/20250326_111322_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_111322_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Changed
-~~~~~~~
-* Replaced the deprecated ``pydocstyle`` library with ``ruff``. (by @bryanttv)

--- a/changelog.d/20250326_111517_bryann.valderrama_add_changelog_entries.rst
+++ b/changelog.d/20250326_111517_bryann.valderrama_add_changelog_entries.rst
@@ -1,3 +1,0 @@
-Added
-~~~~~
-* Migrate to ``scriv`` for manage changelog. (by @bryanttv)

--- a/changelog.d/20250401_114730_bryann.valderrama_add_config_formats_docs.rst
+++ b/changelog.d/20250401_114730_bryann.valderrama_add_config_formats_docs.rst
@@ -1,3 +1,0 @@
-Changed
-~~~~~~~
-* Improved documentation of filter configuration including details on configuration formats. (by @bryanttv)

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.4.1"
+__version__ = "3.5.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -2,6 +2,7 @@
 Package where filters related to the learning architectural subdomain are implemented.
 """
 
+from datetime import datetime
 from typing import Any, Optional
 
 from django.db.models.query import QuerySet
@@ -25,7 +26,7 @@ class AccountSettingsRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.student.settings.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/core/djangoapps/user_api/accounts/settings_views.py
         - Function or Method: account_settings
 
@@ -142,7 +143,7 @@ class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementM
         org.openedx.learning.student.registration.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/core/djangoapps/user_authn/views/register.py
         - Function or Method: RegistrationView.post
     """
@@ -195,7 +196,7 @@ class StudentLoginRequested(OpenEdxPublicFilter):
         org.openedx.learning.student.login.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/core/djangoapps/user_authn/views/login.py
         - Function or Method: login_user
     """
@@ -260,7 +261,7 @@ class CourseEnrollmentStarted(OpenEdxPublicFilter):
         org.openedx.learning.course.enrollment.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: common/djangoapps/student/models/course_enrollment.py
         - Function or Method: enroll
     """
@@ -310,7 +311,7 @@ class CourseUnenrollmentStarted(OpenEdxPublicFilter):
         org.openedx.learning.course.unenrollment.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: common/djangoapps/student/models/course_enrollment.py
         - Function or Method: unenroll
     """
@@ -352,7 +353,7 @@ class CertificateCreationRequested(OpenEdxPublicFilter):
         org.openedx.learning.certificate.creation.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/certificates/generated_certificate.py
         - Function or Method: _generate_certificate_task
     """
@@ -427,7 +428,7 @@ class CertificateRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.certificate.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/certificates/views/webview.py
         - Function or Method: render_html_view
     """
@@ -532,7 +533,7 @@ class CohortChangeRequested(OpenEdxPublicFilter):
         org.openedx.learning.cohort.change.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/core/djangoapps/course_groups/models.py
         - Function or Method: assign
     """
@@ -576,7 +577,7 @@ class CohortAssignmentRequested(OpenEdxPublicFilter):
         org.openedx.learning.cohort.assignment.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/core/djangoapps/course_groups/models.py
         - Function or Method: assign
     """
@@ -624,7 +625,7 @@ class CourseAboutRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.course_about.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/courseware/views/views.py
         - Function or Method: course_about
     """
@@ -737,7 +738,7 @@ class DashboardRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.dashboard.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: common/djangoapps/student/views/dashboard.py
         - Function or Method: student_dashboard
 
@@ -855,7 +856,7 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.vertical_block_child.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: xmodule/vertical_block.py
         - Function or Method: VerticalBlock._student_or_public_view
     """
@@ -940,7 +941,7 @@ class RenderXBlockStarted(OpenEdxPublicFilter):
         org.openedx.learning.xblock.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/courseware/views/views.py
         - Function or Method: render_xblock
     """
@@ -1011,7 +1012,7 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
         org.openedx.learning.vertical_block.render.completed.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: xmodule/vertical_block.py
         - Function or Method: VerticalBlock._student_or_public_view
     """
@@ -1066,7 +1067,7 @@ class CourseHomeUrlCreationStarted(OpenEdxPublicFilter):
         org.openedx.learning.course.homepage.url.creation.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/features/course_experience/__init__.py
         - Function or Method: course_home_url
     """
@@ -1103,7 +1104,7 @@ class CourseEnrollmentAPIRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.home.enrollment.api.rendered.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/learner_home/serializers.py
         - Function or Method: EnrollmentSerializer.to_representation
     """
@@ -1144,7 +1145,7 @@ class CourseRunAPIRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.home.courserun.api.rendered.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/learner_home/serializers.py
         - Function or Method: CourseRunSerializer.to_representation
     """
@@ -1183,7 +1184,7 @@ class InstructorDashboardRenderStarted(OpenEdxPublicFilter):
         org.openedx.learning.instructor.dashboard.render.started.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/instructor/views/instructor_dashboard.py
         - Function or Method: instructor_dashboard_2
     """
@@ -1304,7 +1305,7 @@ class InstructorDashboardTabsRequested(OpenEdxPublicFilter):
         org.openedx.learning.instructor.dashboard.tabs.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/instructor/views/serializers_v2.py
         - Function or Method: CourseInformationSerializerV2.get_tabs
     """
@@ -1430,7 +1431,7 @@ class IDVPageURLRequested(OpenEdxPublicFilter):
         org.openedx.learning.idv.page.url.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: lms/djangoapps/verify_student/services.py
         - Function or Method: XBlockVerificationService.get_verify_location
     """
@@ -1464,7 +1465,7 @@ class CourseAboutPageURLRequested(OpenEdxPublicFilter):
         org.openedx.learning.course_about.page.url.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: common/djangoapps/util/course.py
         - Function or Method: get_link_for_about_page
     """
@@ -1496,13 +1497,13 @@ class ScheduleQuerySetRequested(OpenEdxPublicFilter):
     Purpose:
         This filter is triggered when a QuerySet of Schedules is requested, allowing the filter to act on the schedules
         data. If you want to know more about the Schedules feature, please refer to the official documentation:
-            - https://github.com/openedx/edx-platform/tree/master/openedx/core/djangoapps/schedules#readme
+            - https://github.com/openedx/openedx-platform/tree/master/openedx/core/djangoapps/schedules#readme
 
     Filter Type:
         org.openedx.learning.schedule.queryset.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: openedx/core/djangoapps/schedules/resolvers.py
         - Function or Method: BinnedSchedulesBaseResolver.get_schedules_with_target_date_by_bin_and_orgs
     """
@@ -1601,3 +1602,183 @@ class GradeEventContextRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, user_id=user_id, course_id=course_id)
         return data["context"], data["user_id"], data["course_id"]
+
+
+class CoursewareViewStarted(OpenEdxPublicFilter):
+    """
+    Filter triggered before a courseware view is rendered, allowing pipeline steps to redirect.
+
+    Purpose:
+        Invoked before a courseware view renders. A pipeline step that wants to redirect
+        the user raises the nested ``RedirectToUrl`` exception with the target URL. The
+        platform decorator catches the exception and calls ``django.shortcuts.redirect``.
+
+        The first pipeline step to raise wins; later steps do not run.
+
+    Filter Type:
+        org.openedx.learning.courseware.view.started.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: lms/djangoapps/courseware/decorators.py
+        - Function or Method: courseware_view_hooks
+    """
+
+    filter_type = "org.openedx.learning.courseware.view.started.v1"
+
+    class RedirectToUrl(OpenEdxFilterException):
+        """Raised by a pipeline step to redirect the user before the courseware view renders."""
+
+        def __init__(self, message: str, redirect_to: str) -> None:
+            """Require a redirect URL on the exception instance."""
+            super().__init__(message=message, redirect_to=redirect_to)
+
+    @classmethod
+    def run_filter(cls, course_key: CourseKey, view_name: str) -> tuple[CourseKey, str]:
+        """
+        Run the pipeline so plugins can redirect the user.
+
+        Arguments:
+            course_key (CourseKey): the course key for the view being accessed.
+            view_name (str): name of the view function being accessed (e.g. 'index', 'progress'),
+                used by pipeline steps for logging/auditing purposes.
+
+        Returns:
+            tuple[CourseKey, str]: ``(course_key, view_name)``, unchanged.
+
+        Note:
+            Pipeline steps that need the current request should obtain it via
+            ``crum.get_current_request()`` rather than expecting it as a kwarg.
+        """
+        data = super().run_pipeline(course_key=course_key, view_name=view_name)
+        return data["course_key"], data["view_name"]
+
+
+class CourseStartDateValidationFailed(OpenEdxPublicFilter):
+    """
+    Filter triggered from the failure branch of the course start-date access check.
+
+    Purpose:
+        Invoked after start-date validation has already failed for the base case,
+        allowing pipeline steps to substitute a more specific access-error payload.
+        A step that wants to override the default error raises the nested
+        ``OverrideStartDateError`` exception; the platform catches it and builds a
+        ``StartDateFiltersError`` from the exception's fields.
+
+        The first pipeline step to raise wins; later steps do not run.
+
+    Filter Type:
+        org.openedx.learning.course.start_date.validation_failed.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: lms/djangoapps/courseware/access_utils.py
+        - Function or Method: check_start_date
+    """
+
+    filter_type = "org.openedx.learning.course.start_date.validation_failed.v1"
+
+    class OverrideStartDateError(OpenEdxFilterException):
+        """
+        Raised by a pipeline step to substitute a more specific start-date access error.
+
+        The caller decides whether to surface ``user_message`` in the UI.
+        """
+
+        def __init__(
+            self,
+            message: str,
+            error_code: str,
+            developer_message: str,
+            user_message: str,
+        ) -> None:
+            """Store error fields on the exception instance."""
+            super().__init__(message=message)
+            # Explicit assignments keep pylint's no-member check happy; the base
+            # class would set these via **kwargs setattr but pylint can't see that.
+            self.error_code = error_code
+            self.developer_message = developer_message
+            self.user_message = user_message
+
+    @classmethod
+    def run_filter(
+        cls,
+        course_key: CourseKey,
+        start_date: datetime,
+    ) -> tuple[CourseKey, datetime]:
+        """
+        Run the pipeline so plugins can substitute a more specific start-date error.
+
+        Arguments:
+            course_key (CourseKey): the course key for the view being accessed.
+            start_date (datetime): the course start date.
+
+        Returns:
+            tuple[CourseKey, datetime]: the inputs unchanged.
+        """
+        data = super().run_pipeline(
+            course_key=course_key,
+            start_date=start_date,
+        )
+        return data["course_key"], data["start_date"]
+
+
+class CoursewareAccessChecksRequested(OpenEdxPublicFilter):
+    """
+    Filter triggered during courseware access checks so plugins can deny access.
+
+    Purpose:
+        Invoked from the courseware access-check flow after platform-internal
+        checks have passed. Pipeline steps that wish to deny access raise the
+        nested ``PreventCoursewareAccess`` exception, which the framework
+        propagates back to the caller regardless of ``fail_silently``. Denials
+        surfaced through this filter are treated as priority — i.e. they cannot
+        be bypassed by staff users.
+
+        The first pipeline step to raise wins; later steps do not run.
+
+    Filter Type:
+        org.openedx.learning.courseware.access_checks.requested.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: lms/djangoapps/courseware/courses.py
+        - Function or Method: check_course_access
+    """
+
+    filter_type = "org.openedx.learning.courseware.access_checks.requested.v1"
+
+    class PreventCoursewareAccess(OpenEdxFilterException):
+        """
+        Raised by a pipeline step to deny courseware access.
+        """
+
+        def __init__(
+            self,
+            message: str,
+            error_code: str,
+            developer_message: str,
+            user_message: str,
+        ) -> None:
+            """Store error fields on the exception instance."""
+            super().__init__(message=message)
+            # Explicit assignments keep pylint's no-member check happy; the base
+            # class would set these via **kwargs setattr but pylint can't see that.
+            self.error_code = error_code
+            self.developer_message = developer_message
+            self.user_message = user_message
+
+    @classmethod
+    def run_filter(cls, user: Any, course_key: CourseKey) -> tuple[Any, CourseKey]:
+        """
+        Run the pipeline so plugins can deny access.
+
+        Arguments:
+            user: the user whose access is being checked.
+            course_key: the course key being accessed.
+
+        Returns:
+            tuple[Any, CourseKey]: ``(user, course_key)``, unchanged.
+        """
+        data = super().run_pipeline(user=user, course_key=course_key)
+        return data["user"], data["course_key"]

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -1,11 +1,13 @@
 """
 Tests for learning subdomain filters.
 """
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 # Ignore the type error for ddt import since it is not recognized by mypy.
 from ddt import data, ddt, unpack  # type: ignore
 from django.test import TestCase
+from opaque_keys.edx.keys import CourseKey
 
 from openedx_filters.learning.filters import (
     AccountSettingsReadOnlyFieldsRequested,
@@ -21,7 +23,10 @@ from openedx_filters.learning.filters import (
     CourseEnrollmentStarted,
     CourseHomeUrlCreationStarted,
     CourseRunAPIRenderStarted,
+    CourseStartDateValidationFailed,
     CourseUnenrollmentStarted,
+    CoursewareAccessChecksRequested,
+    CoursewareViewStarted,
     DashboardRenderStarted,
     GradeEventContextRequested,
     IDVPageURLRequested,
@@ -966,3 +971,112 @@ class TestInstructorDashboardTabsRequested(TestCase):
         exception = exception_class(**attributes)
 
         self.assertLessEqual(attributes.items(), exception.__dict__.items())
+
+
+class TestCoursewareViewStarted(TestCase):
+    """
+    Test class to verify standard behavior of the CoursewareViewStarted filter.
+    """
+
+    def test_returns_course_key_unchanged_when_no_pipeline_steps(self):
+        """
+        Test CoursewareViewStarted filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter returns ``course_key`` unchanged when no pipeline steps raise.
+        """
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        view_name = "test_view"
+        result_course_key, result_view_name = CoursewareViewStarted.run_filter(
+            course_key=course_key,
+            view_name=view_name,
+        )
+        assert result_course_key == course_key
+        assert result_view_name == view_name
+
+    def test_redirect_to_url_stores_url(self):
+        """
+        Test that RedirectToUrl stores the redirect_to attribute on the exception instance.
+
+        Expected behavior:
+            - Instantiating RedirectToUrl sets ``exc.redirect_to`` to the provided value.
+        """
+        exc = CoursewareViewStarted.RedirectToUrl(message="test message", redirect_to="/some/path/")
+        assert exc.message == "test message"
+        assert exc.redirect_to == "/some/path/"
+
+
+class TestCourseStartDateValidationFailed(TestCase):
+    """
+    Test class to verify standard behavior of the CourseStartDateValidationFailed filter.
+    """
+
+    def test_returns_inputs_unchanged_when_no_pipeline_steps(self):
+        """
+        Test CourseStartDateValidationFailed filter behavior under normal conditions.
+
+        Expected behavior:
+            - Each input field is returned unchanged when no pipeline steps raise.
+        """
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        start_date = datetime(2026, 9, 1)
+        result_course_key, result_start_date = CourseStartDateValidationFailed.run_filter(
+            course_key=course_key,
+            start_date=start_date,
+        )
+        assert result_course_key == course_key
+        assert result_start_date == start_date
+
+    def test_override_start_date_error_stores_fields(self):
+        """
+        Test that OverrideStartDateError stores all fields on the exception instance.
+
+        Expected behavior:
+            - Instantiating OverrideStartDateError sets ``message``, ``error_code``,
+              ``developer_message``, and ``user_message`` on the instance.
+        """
+        exc = CourseStartDateValidationFailed.OverrideStartDateError(
+            message="Course has not started (message).",
+            error_code="course_not_started",
+            developer_message="Course has not started (developer message).",
+            user_message="Course has not started (user message).",
+        )
+        assert exc.message == "Course has not started (message)."
+        assert exc.error_code == "course_not_started"
+        assert exc.developer_message == "Course has not started (developer message)."
+        assert exc.user_message == "Course has not started (user message)."
+
+
+class TestCoursewareAccessChecksRequested(TestCase):
+    """
+    Test class to verify standard behavior of the CoursewareAccessChecksRequested filter.
+    """
+
+    def test_returns_inputs_unchanged_when_no_pipeline_steps(self):
+        """
+        Filter passes through user and course_key when no pipeline steps are configured.
+        """
+        user = Mock()
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        result_user, result_course_key = CoursewareAccessChecksRequested.run_filter(
+            user=user,
+            course_key=course_key,
+        )
+        assert result_user == user
+        assert result_course_key == course_key
+
+    def test_prevent_exception_preserves_kwargs(self):
+        """
+        PreventCoursewareAccess stores message, error_code, developer_message, and
+        user_message as attributes on the exception instance.
+        """
+        exc = CoursewareAccessChecksRequested.PreventCoursewareAccess(
+            message="test message",
+            error_code="some_code",
+            developer_message="developer message",
+            user_message="user message",
+        )
+        assert exc.message == "test message"
+        assert exc.error_code == "some_code"
+        assert exc.developer_message == "developer message"
+        assert exc.user_message == "user message"


### PR DESCRIPTION
Plugins can now supply a courseware view redirect URL, inject specific error
payloads when course start-date validation fails, or deny courseware access
with a priority (non-bypassable) error.

ENT-11544

---

Blocks:
* https://github.com/openedx/edx-enterprise/pull/2548
* https://github.com/edx/edx-platform/pull/338
* https://github.com/edx/edx-platform/pull/339
* https://github.com/edx/edx-platform/pull/340
* https://github.com/openedx/openedx-platform/pull/38102