### PR TITLE
feat: add contextmanager-based management command observability filter

### DIFF
--- a/openedx_filters/management/__init__.py
+++ b/openedx_filters/management/__init__.py
@@ -1,0 +1,3 @@
+"""
+Package where filters related to management command execution are implemented.
+"""

--- a/openedx_filters/management/filters.py
+++ b/openedx_filters/management/filters.py
@@ -1,0 +1,53 @@
+"""
+Package where filters related to management command execution are implemented.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
+    """
+    Filter used to modify the execution of Django management commands.
+
+    Purpose:
+        This filter is triggered in ``manage.py`` before a management command is
+        executed, allowing pipeline steps to wrap or replace the command runner.
+
+    Filter Type:
+        org.openedx.platform.management.command.execute.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: manage.py
+        - Function or Method: __main__
+    """
+
+    filter_type = "org.openedx.platform.management.command.execute.requested.v1"
+
+    @classmethod
+    def run_filter(
+        cls,
+        command_name: str,
+        service_variant: str,
+        command_runner: Callable[..., Any],
+    ) -> dict[str, Any]:
+        """
+        Process management command execution arguments through the pipeline.
+
+        Arguments:
+            command_name (str): name of the management command being executed.
+            service_variant (str): service variant, such as lms or cms.
+            command_runner (Callable): callable that executes the command.
+
+        Returns:
+            dict[str, Any]: accumulated pipeline output, including possibly
+                modified command metadata and command runner.
+        """
+        return super().run_pipeline(
+            command_name=command_name,
+            service_variant=service_variant,
+            command_runner=command_runner,
+        )

--- a/openedx_filters/management/filters.py
+++ b/openedx_filters/management/filters.py
@@ -19,7 +19,7 @@ class ManagementCommandContextmanagerRequested(OpenEdxPublicFilter):
         org.openedx.platform.management.command.contextmanager.requested.v1
 
     Trigger:
-        - Repository: edx/edx-platform
+        - Repository: openedx/openedx-platform
         - Path: manage.py
         - Function or Method: __main__
     """

--- a/openedx_filters/management/filters.py
+++ b/openedx_filters/management/filters.py
@@ -20,7 +20,7 @@ class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
         org.openedx.platform.management.command.execute.requested.v1
 
     Trigger:
-        - Repository: openedx/edx-platform
+        - Repository: edx/edx-platform
         - Path: manage.py
         - Function or Method: __main__
     """

--- a/openedx_filters/management/filters.py
+++ b/openedx_filters/management/filters.py
@@ -2,22 +2,21 @@
 Package where filters related to management command execution are implemented.
 """
 
-from collections.abc import Callable
-from typing import Any
+from contextlib import AbstractContextManager
 
 from openedx_filters.tooling import OpenEdxPublicFilter
 
 
-class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
+class ManagementCommandContextmanagerRequested(OpenEdxPublicFilter):
     """
-    Filter used to modify the execution of Django management commands.
+    Filter used to wrap Django management command execution in a context manager.
 
     Purpose:
         This filter is triggered in ``manage.py`` before a management command is
-        executed, allowing pipeline steps to wrap or replace the command runner.
+        executed, allowing pipeline steps to provide a context manager wrapper.
 
     Filter Type:
-        org.openedx.platform.management.command.execute.requested.v1
+        org.openedx.platform.management.command.contextmanager.requested.v1
 
     Trigger:
         - Repository: edx/edx-platform
@@ -25,29 +24,36 @@ class ManagementCommandExecutionRequested(OpenEdxPublicFilter):
         - Function or Method: __main__
     """
 
-    filter_type = "org.openedx.platform.management.command.execute.requested.v1"
+    filter_type = "org.openedx.platform.management.command.contextmanager.requested.v1"
 
     @classmethod
     def run_filter(
         cls,
+        command_contextmanager: AbstractContextManager[None],
         command_name: str,
         service_variant: str,
-        command_runner: Callable[..., Any],
-    ) -> dict[str, Any]:
+    ) -> tuple[AbstractContextManager[None], str, str]:
         """
-        Process management command execution arguments through the pipeline.
+        Process management command context manager arguments through the pipeline.
 
         Arguments:
+            command_contextmanager (AbstractContextManager[None]): context manager used to wrap command execution.
             command_name (str): name of the management command being executed.
             service_variant (str): service variant, such as lms or cms.
-            command_runner (Callable): callable that executes the command.
 
         Returns:
-            dict[str, Any]: accumulated pipeline output, including possibly
-                modified command metadata and command runner.
+            tuple[AbstractContextManager[None], str, str]:
+                - context manager used to wrap command execution.
+                - name of the management command.
+                - service variant, such as lms or cms.
         """
-        return super().run_pipeline(
+        data = super().run_pipeline(
+            command_contextmanager=command_contextmanager,
             command_name=command_name,
             service_variant=service_variant,
-            command_runner=command_runner,
+        )
+        return (
+            data.get("command_contextmanager", command_contextmanager),
+            data.get("command_name", command_name),
+            data.get("service_variant", service_variant),
         )

--- a/openedx_filters/management/tests/test_filters.py
+++ b/openedx_filters/management/tests/test_filters.py
@@ -1,0 +1,35 @@
+"""
+Tests for management subdomain filters.
+"""
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from openedx_filters.management.filters import ManagementCommandExecutionRequested
+
+
+class TestManagementFilters(TestCase):
+    """
+    Test class to verify standard behavior of management filters.
+    """
+
+    def test_management_command_execution_requested(self):
+        """
+        Test ManagementCommandExecutionRequested filter behavior.
+
+        Expected behavior:
+            - The filter should return management command metadata and runner.
+        """
+        command_name = "migrate"
+        service_variant = "lms"
+        command_runner = Mock()
+
+        result = ManagementCommandExecutionRequested.run_filter(
+            command_name=command_name,
+            service_variant=service_variant,
+            command_runner=command_runner,
+        )
+
+        self.assertEqual(command_name, result.get("command_name"))
+        self.assertEqual(service_variant, result.get("service_variant"))
+        self.assertEqual(command_runner, result.get("command_runner"))

--- a/openedx_filters/management/tests/test_filters.py
+++ b/openedx_filters/management/tests/test_filters.py
@@ -1,11 +1,11 @@
 """
 Tests for management subdomain filters.
 """
-from unittest.mock import Mock
+from contextlib import nullcontext
 
 from django.test import TestCase
 
-from openedx_filters.management.filters import ManagementCommandExecutionRequested
+from openedx_filters.management.filters import ManagementCommandContextmanagerRequested
 
 
 class TestManagementFilters(TestCase):
@@ -13,23 +13,27 @@ class TestManagementFilters(TestCase):
     Test class to verify standard behavior of management filters.
     """
 
-    def test_management_command_execution_requested(self):
+    def test_management_command_contextmanager_requested(self):
         """
-        Test ManagementCommandExecutionRequested filter behavior.
+        Test ManagementCommandContextmanagerRequested filter behavior.
 
         Expected behavior:
-            - The filter should return management command metadata and runner.
+            - The filter should return context manager and command metadata.
         """
+        command_contextmanager = nullcontext()
         command_name = "migrate"
         service_variant = "lms"
-        command_runner = Mock()
 
-        result = ManagementCommandExecutionRequested.run_filter(
+        (
+            filtered_command_contextmanager,
+            filtered_command_name,
+            filtered_service_variant,
+        ) = ManagementCommandContextmanagerRequested.run_filter(
+            command_contextmanager=command_contextmanager,
             command_name=command_name,
             service_variant=service_variant,
-            command_runner=command_runner,
         )
 
-        self.assertEqual(command_name, result.get("command_name"))
-        self.assertEqual(service_variant, result.get("service_variant"))
-        self.assertEqual(command_runner, result.get("command_runner"))
+        self.assertEqual(command_contextmanager, filtered_command_contextmanager)
+        self.assertEqual(command_name, filtered_command_name)
+        self.assertEqual(service_variant, filtered_service_variant)

--- a/openedx_filters/management/tests/test_filters.py
+++ b/openedx_filters/management/tests/test_filters.py
@@ -34,6 +34,6 @@ class TestManagementFilters(TestCase):
             service_variant=service_variant,
         )
 
-        self.assertEqual(command_contextmanager, filtered_command_contextmanager)
-        self.assertEqual(command_name, filtered_command_name)
-        self.assertEqual(service_variant, filtered_service_variant)
+        assert command_contextmanager == filtered_command_contextmanager
+        assert command_name == filtered_command_name
+        assert service_variant == filtered_service_variant

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
-django==5.2.14
+django==5.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -18,9 +18,9 @@ pymongo==4.17.0
     # via edx-opaque-keys
 sqlparse==0.5.5
     # via django
-stevedore==5.7.0
+stevedore==5.9.0
     # via edx-opaque-keys
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via edx-opaque-keys
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-cachetools==7.1.1
+cachetools==7.1.6
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
-filelock==3.29.0
+filelock==3.32.2
     # via
     #   python-discovery
     #   tox
@@ -19,22 +19,22 @@ packaging==26.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.9.6
+platformdirs==4.11.0
     # via
     #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
-pyproject-api==1.10.0
+pyproject-api==1.11.0
     # via tox
-python-discovery==1.3.0
+python-discovery==1.5.0
     # via
     #   tox
     #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.53.1
+tox==4.58.0
     # via -r requirements/ci.in
-virtualenv==21.3.1
+virtualenv==21.7.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/quality.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via
     #   -r requirements/quality.txt
     #   mypy
@@ -23,25 +23,25 @@ build==1.5.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.1.1
+cachetools==7.1.6
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2026.4.22
+certifi==2026.7.22
     # via
     #   -r requirements/quality.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/quality.txt
     #   cryptography
 chardet==7.4.3
     # via diff-cover
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.3.3
+click==8.4.2
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -63,35 +63,35 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.14.0
+coverage[toml]==7.15.2
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==48.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/quality.txt
     #   secretstorage
 ddt==1.7.2
     # via -r requirements/quality.txt
-diff-cover==10.2.0
+diff-cover==10.4.1
     # via -r requirements/dev.in
 dill==0.4.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.4.0
+distlib==0.4.3
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==5.2.14
+django==5.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.0.7
     # via -r requirements/quality.txt
-django-stubs-ext==6.0.4
+django-stubs-ext==6.0.7
     # via
     #   -r requirements/quality.txt
     #   django-stubs
@@ -99,7 +99,7 @@ dnspython==2.8.0
     # via
     #   -r requirements/quality.txt
     #   pymongo
-docutils==0.22.4
+docutils==0.23
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -107,7 +107,7 @@ edx-lint==6.1.0
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==4.0.0
     # via -r requirements/quality.txt
-filelock==3.29.0
+filelock==3.32.2
     # via
     #   -r requirements/ci.txt
     #   python-discovery
@@ -117,7 +117,7 @@ id==1.6.1
     # via
     #   -r requirements/quality.txt
     #   twine
-idna==3.14
+idna==3.18
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -137,7 +137,7 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -156,7 +156,7 @@ keyring==25.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
-librt==0.11.0
+librt==0.13.0
     # via
     #   -r requirements/quality.txt
     #   mypy
@@ -177,18 +177,18 @@ mdurl==0.1.2
     # via
     #   -r requirements/quality.txt
     #   markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-mypy==2.0.0
+mypy==2.3.0
     # via -r requirements/quality.txt
 mypy-extensions==1.1.0
     # via
     #   -r requirements/quality.txt
     #   mypy
-nh3==0.3.5
+nh3==0.3.6
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -207,9 +207,9 @@ pathspec==1.1.1
     # via
     #   -r requirements/quality.txt
     #   mypy
-pip-tools==7.5.3
+pip-tools==7.6.0
     # via -r requirements/pip-tools.txt
-platformdirs==4.9.6
+platformdirs==4.11.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -238,7 +238,7 @@ pygments==2.20.0
     #   pytest
     #   readme-renderer
     #   rich
-pylint==4.0.5
+pylint==4.0.6
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -249,7 +249,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -262,7 +262,7 @@ pymongo==4.17.0
     # via
     #   -r requirements/quality.txt
     #   edx-opaque-keys
-pyproject-api==1.10.0
+pyproject-api==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -271,7 +271,7 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -280,7 +280,7 @@ pytest-cov==7.1.0
     # via -r requirements/quality.txt
 pytest-django==4.12.0
     # via -r requirements/quality.txt
-python-discovery==1.3.0
+python-discovery==1.5.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -293,11 +293,11 @@ pyyaml==6.0.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-readme-renderer==44.0
+readme-renderer==45.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/quality.txt
     #   requests-toolbelt
@@ -315,7 +315,7 @@ rich==15.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-ruff==0.15.12
+ruff==0.16.0
     # via -r requirements/quality.txt
 scriv==1.8.0
     # via -r requirements/dev.in
@@ -331,7 +331,7 @@ sqlparse==0.5.5
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==5.7.0
+stevedore==5.9.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -344,20 +344,20 @@ tomli-w==1.2.0
     # via
     #   -r requirements/ci.txt
     #   tox
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via
     #   -r requirements/quality.txt
     #   edx-lint
     #   pylint
-tox==4.53.1
+tox==4.58.0
     # via -r requirements/ci.txt
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/quality.txt
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260724
     # via
     #   -r requirements/quality.txt
     #   django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/quality.txt
     #   django-stubs
@@ -370,7 +370,7 @@ urllib3==2.7.0
     #   id
     #   requests
     #   twine
-virtualenv==21.3.1
+virtualenv==21.7.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,15 +8,15 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   starlette
     #   watchfiles
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/test.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -24,17 +24,17 @@ babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
     # via pydata-sphinx-theme
 build==1.5.0
     # via -r requirements/doc.in
-certifi==2026.4.22
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.3.3
+click==8.4.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -43,23 +43,23 @@ code-annotations==3.0.0
     # via -r requirements/test.txt
 colorama==0.4.6
     # via sphinx-autobuild
-coverage[toml]==7.14.0
+coverage[toml]==7.15.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
+cryptography==49.0.0
     # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-django==5.2.14
+django==5.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.0.7
     # via -r requirements/test.txt
-django-stubs-ext==6.0.4
+django-stubs-ext==6.0.7
     # via
     #   -r requirements/test.txt
     #   django-stubs
@@ -82,7 +82,7 @@ h11==0.16.0
     # via uvicorn
 id==1.6.1
     # via twine
-idna==3.14
+idna==3.18
     # via
     #   anyio
     #   requests
@@ -96,7 +96,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -106,11 +106,12 @@ jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   pydata-sphinx-theme
     #   sphinx
     #   sphinxcontrib-mermaid
 keyring==25.7.0
     # via twine
-librt==0.11.0
+librt==0.13.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -122,17 +123,17 @@ markupsafe==3.0.3
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==2.0.0
+mypy==2.3.0
     # via -r requirements/test.txt
 mypy-extensions==1.1.0
     # via
     #   -r requirements/test.txt
     #   mypy
-nh3==0.3.5
+nh3==0.3.6
     # via readme-renderer
 packaging==26.2
     # via
@@ -152,7 +153,7 @@ pluggy==1.6.0
     #   pytest-cov
 pycparser==3.0
     # via cffi
-pydata-sphinx-theme==0.16.1
+pydata-sphinx-theme==0.20.0
     # via sphinx-book-theme
 pygments==2.20.0
     # via
@@ -170,7 +171,7 @@ pymongo==4.17.0
     #   edx-opaque-keys
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -188,10 +189,11 @@ pyyaml==6.0.3
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinxcontrib-mermaid
-readme-renderer==44.0
+readme-renderer==45.0
     # via twine
-requests==2.33.1
+requests==2.34.2
     # via
+    #   pydata-sphinx-theme
     #   requests-toolbelt
     #   sphinx
     #   twine
@@ -207,9 +209,9 @@ roman-numerals==4.1.0
     # via sphinx
 secretstorage==3.5.0
     # via keyring
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
-soupsieve==2.8.3
+soupsieve==2.9.1
     # via beautifulsoup4
 sphinx==9.1.0
     # via
@@ -221,7 +223,7 @@ sphinx==9.1.0
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2025.8.25
     # via -r requirements/doc.in
-sphinx-book-theme==1.2.0
+sphinx-book-theme==1.4.0
     # via -r requirements/doc.in
 sphinx-copybutton==0.5.2
     # via -r requirements/doc.in
@@ -233,7 +235,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-mermaid==2.0.2
+sphinxcontrib-mermaid==2.1.0
     # via -r requirements/doc.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
@@ -243,9 +245,9 @@ sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-starlette==1.0.0
+starlette==1.3.1
     # via sphinx-autobuild
-stevedore==5.7.0
+stevedore==5.9.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -255,13 +257,13 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/doc.in
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260724
     # via
     #   -r requirements/test.txt
     #   django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/test.txt
     #   anyio
@@ -270,16 +272,15 @@ typing-extensions==4.15.0
     #   django-stubs-ext
     #   edx-opaque-keys
     #   mypy
-    #   pydata-sphinx-theme
     #   starlette
 urllib3==2.7.0
     # via
     #   id
     #   requests
     #   twine
-uvicorn==0.46.0
+uvicorn==0.52.0
     # via sphinx-autobuild
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via sphinx-autobuild
-websockets==16.0
+websockets==17.0
     # via sphinx-autobuild

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,13 +6,13 @@
 #
 build==1.5.0
     # via pip-tools
-click==8.3.3
+click==8.4.2
     # via pip-tools
 packaging==26.2
     # via
     #   build
     #   wheel
-pip-tools==7.5.3
+pip-tools==7.6.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,6 +1,6 @@
 # Core dependencies for installing other packages
 -c constraints.txt
 
-pip
+pip<25.0
 setuptools
 wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.1
+pip==24.3.1
     # via -r requirements/pip.in
-setuptools==82.0.1
+setuptools==83.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/test.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -16,13 +16,13 @@ astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-certifi==2026.4.22
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.3.3
+click==8.4.2
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -34,25 +34,25 @@ code-annotations==3.0.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.14.0
+coverage[toml]==7.15.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
+cryptography==49.0.0
     # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.4.1
     # via pylint
-django==5.2.14
+django==5.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.0.7
     # via -r requirements/test.txt
-django-stubs-ext==6.0.4
+django-stubs-ext==6.0.7
     # via
     #   -r requirements/test.txt
     #   django-stubs
@@ -60,7 +60,7 @@ dnspython==2.8.0
     # via
     #   -r requirements/test.txt
     #   pymongo
-docutils==0.22.4
+docutils==0.23
     # via readme-renderer
 edx-lint==6.1.0
     # via -r requirements/quality.in
@@ -68,7 +68,7 @@ edx-opaque-keys[django]==4.0.0
     # via -r requirements/test.txt
 id==1.6.1
     # via twine
-idna==3.14
+idna==3.18
     # via requests
 iniconfig==2.3.0
     # via
@@ -82,7 +82,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -94,7 +94,7 @@ jinja2==3.1.6
     #   code-annotations
 keyring==25.7.0
     # via twine
-librt==0.11.0
+librt==0.13.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -108,11 +108,11 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==2.0.0
+mypy==2.3.0
     # via
     #   -r requirements/quality.in
     #   -r requirements/test.txt
@@ -120,7 +120,7 @@ mypy-extensions==1.1.0
     # via
     #   -r requirements/test.txt
     #   mypy
-nh3==0.3.5
+nh3==0.3.6
     # via readme-renderer
 packaging==26.2
     # via
@@ -131,7 +131,7 @@ pathspec==1.1.1
     # via
     #   -r requirements/test.txt
     #   mypy
-platformdirs==4.9.6
+platformdirs==4.11.0
     # via pylint
 pluggy==1.6.0
     # via
@@ -148,7 +148,7 @@ pygments==2.20.0
     #   pytest
     #   readme-renderer
     #   rich
-pylint==4.0.5
+pylint==4.0.6
     # via
     #   edx-lint
     #   pylint-celery
@@ -156,7 +156,7 @@ pylint==4.0.5
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
@@ -166,7 +166,7 @@ pymongo==4.17.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -183,9 +183,9 @@ pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==44.0
+readme-renderer==45.0
     # via twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   requests-toolbelt
     #   twine
@@ -195,7 +195,7 @@ rfc3986==2.0.0
     # via twine
 rich==15.0.0
     # via twine
-ruff==0.15.12
+ruff==0.16.0
     # via -r requirements/quality.in
 secretstorage==3.5.0
     # via keyring
@@ -205,7 +205,7 @@ sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.7.0
+stevedore==5.9.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -214,17 +214,17 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via
     #   edx-lint
     #   pylint
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/quality.in
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260724
     # via
     #   -r requirements/test.txt
     #   django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/test.txt
     #   django-stubs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/base.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via mypy
-click==8.3.3
+click==8.4.2
     # via code-annotations
 code-annotations==3.0.0
     # via -r requirements/test.in
-coverage[toml]==7.14.0
+coverage[toml]==7.15.2
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
@@ -23,9 +23,9 @@ ddt==1.7.2
     #   -r requirements/base.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.0.7
     # via -r requirements/test.in
-django-stubs-ext==6.0.4
+django-stubs-ext==6.0.7
     # via django-stubs
 dnspython==2.8.0
     # via
@@ -37,11 +37,11 @@ iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
     # via code-annotations
-librt==0.11.0
+librt==0.13.0
     # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==2.0.0
+mypy==2.3.0
     # via -r requirements/test.in
 mypy-extensions==1.1.0
     # via mypy
@@ -59,7 +59,7 @@ pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -75,16 +75,16 @@ sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.7.0
+stevedore==5.9.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260724
     # via django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/base.txt
     #   django-stubs


### PR DESCRIPTION
## Summary

This PR introduces the ManagementCommandContextmanagerRequested filter under the openedx_filters.management package.

The filter is invoked before a Django management command is executed, allowing plugins to inspect or modify the context manager, command name, and service variant through the standard Open edX filter pipeline. It follows the conventional filter contract where the inputs map directly to the returned tuple.

This PR also includes unit tests verifying the filter returns the expected values when no pipeline steps modify the inputs.

## Changes
Added the openedx_filters.management package.
Added the ManagementCommandContextmanagerRequested public filter.
Added unit tests for the filter's default behavior.
