### PR TITLE
build: Remove outdated sphinx-contentui package

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,6 @@ release = 'latest'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinxcontrib.contentui',
     'sphinx_copybutton',
     'sphinx.ext.graphviz',
     'sphinxcontrib.mermaid',

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -11,4 +11,4 @@ sphinx-book-theme
 sphinx-copybutton
 sphinx-autobuild
 sphinxcontrib-mermaid
-sphinxcontrib-contentui
+

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,8 +26,6 @@ build==1.4.2
     # via -r requirements/doc.in
 certifi==2026.2.25
     # via requests
-cffi==2.0.0
-    # via cryptography
 charset-normalizer==3.4.7
     # via requests
 click==8.3.2
@@ -43,14 +41,11 @@ coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.6
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-django==5.2.12
+django==5.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.txt
     #   django-stubs
     #   django-stubs-ext
 django-stubs==6.0.2
@@ -94,10 +89,6 @@ jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
@@ -146,8 +137,6 @@ pluggy==1.6.0
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
-pycparser==3.0
-    # via cffi
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.20.0
@@ -201,8 +190,6 @@ rich==14.3.3
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-secretstorage==3.5.0
-    # via keyring
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.8.3
@@ -214,7 +201,6 @@ sphinx==9.1.0
     #   sphinx-autobuild
     #   sphinx-book-theme
     #   sphinx-copybutton
-    #   sphinxcontrib-contentui
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2025.8.25
     # via -r requirements/doc.in
@@ -224,8 +210,6 @@ sphinx-copybutton==0.5.2
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-contentui==0.2.5
-    # via -r requirements/doc.in
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
@@ -276,7 +260,7 @@ urllib3==2.6.3
     #   id
     #   requests
     #   twine
-uvicorn==0.43.0
+uvicorn==0.44.0
     # via sphinx-autobuild
 watchfiles==1.1.1
     # via sphinx-autobuild


### PR DESCRIPTION
See https://github.com/openedx/docs.openedx.org/pull/1417

This is an outdated package that was included in the docs cookie cutter. It can cause build errors and doesn't seem to be used.