### PR TITLE
fix: expand Python version compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.12']
         toxenv: ["django42", "django52", "quality", "docs"]
+        # [TEMP] include 3.11 tests until most operators developing filters have migrated to Verawood/Python 3.12.
+        include:
+          - os: ubuntu-latest
+            python-version: '3.11'
+            toxenv: "py311-django42"
+          - os: ubuntu-latest
+            python-version: '3.11'
+            toxenv: "py311-django52"
 
     steps:
     - uses: actions/checkout@v6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,8 +32,6 @@ Change Log
 Unreleased
 ----------
 
-[2.1.0] - 2025-04-23
-
 Added
 ~~~~~
 
@@ -44,6 +42,13 @@ See the fragment files in the `changelog.d directory`_.
 .. _changelog.d directory: https://github.com/openedx/openedx-filters/tree/master/changelog.d
 .. scriv-insert-here
 
+[3.3.0] - 2025-04-17
+--------------------
+
+Changed
+~~~~~~~
+
+* Expand Python version compatibility
 
 [2.0.1] - 2025-02-18
 --------------------

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -1,6 +1,17 @@
 """
 Filters of the Open edX platform.
 """
+import sys
+import warnings
+
 from openedx_filters.filters import *
 
-__version__ = "3.0.0"
+__version__ = "3.3.0"
+
+if sys.version_info < (3, 12):
+    warnings.warn(
+        "Python 3.11 support is deprecated and will be removed in a future release. "
+        "Please upgrade to Python 3.12 or later.",
+        DeprecationWarning,
+        stacklevel=2,
+    )

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=load_requirements("requirements/base.in"),
-    python_requires=">=3.12",
+    python_requires=">=3.11",
     license="AGPL 3.0",
     zip_safe=False,
     keywords="Python openedx",


### PR DESCRIPTION
<!--

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

Fore more details on the Hooks Extension Framework contribution process, see:

https://docs.openedx.org/en/latest/developers/concepts/hooks_extension_framework.html

-->

## Description

This PR adds the flexibility to support Python 3.11 as well as 3.12 to unblock work [to transition all enterprise code into well-defined plugin hooks](https://discuss.openedx.org/t/rfc-pluginifying-edx-enterprise-looking-for-community-interest-collaborators/18316). 

## Motivation:
Right now, the repo works well with both python 3.11 and 3.12 ([link](https://github.com/pwnage101/openedx-filters/blob/ccf780ff2fa9501858b0320eda9b2cbbc538ed6d/.github/workflows/ci.yml#L18)), but the constraint in the setup file deems that only versions past 3.12 are allowed.

This blocks all of the work that the Titans team (enterprise team at 2u)  is doing to deploy new plugins, as they have not yet migrated to 3.12 in edx/edx-platform. This in turn is slowing down the work of removing the hard dependency of the platform code in the edx-enterprise repos.

There is no specific functionality that is being used from python 3.12, so this would unblock that initiative.


## Supporting information

To speed this up, some maintainers were pinged via slack, but they are also asked as reviewers here.

The proposal here is to allow installers to use in 3.11 at their own risk. CI testing would remain using 3.12 only.

## Testing instructions

It is possible to run the test suite using 3.11.

``` bash
  python3.11 -m venv .venv311
  source .venv311/bin/activate                                                                                                                                                             
  pip install -e ".[dev]"   # or pip install -e . && pip install -r requirements/test.txt
  python -m pytest                                                                                                                                                                         
  Expected: all tests pass without syntax errors or import failures.
```


## Deadline

Soon if possible to speed up the work of removing enterprise.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog entry added using scriv with short description of the change
- [ ] Documentation updated (not only docstrings)

**Post Merge:**
- [ ] Trigger the release workflow to create a new GitHub release.
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
