### PR TITLE
chore: update team_reviewers to match latest team conventions

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,7 +17,7 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
-      team_reviewers: "hooks-extension-framework"
+      team_reviewers: "committers-openedx-filters"
       # email_address: ""
       # send_success_notification: false
     secrets:


### PR DESCRIPTION
<!--

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

For more details on the Hooks Extension Framework contribution process, see:

https://docs.openedx.org/en/latest/developers/concepts/hooks_extension_framework.html

-->

## Description

The "Upgrade Python Requirements" workflow was partially failing because of the step "create pull request" which couldn't tag team reviewers that pointed to an out of date team: https://github.com/openedx/openedx-events/actions/runs/24643061070/job/72050417661

## Supporting information

https://openedx.atlassian.net/wiki/spaces/COMM/pages/3555852316/GitHub+Access+Team+Structure

## Testing instructions

You can see a successfull run here: https://github.com/openedx/openedx-events/actions/runs/24664886728/job/72119882641 

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [ ] Version bumped NA
- [ ] Changelog record added with short description of the change and current date NA
- [ ] Documentation updated (not only docstrings) NA
- [ ] Integration with other services reviewed NA
- [ ] Fixup commits are squashed away NA
- [ ] Unit tests added/updated NA
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets NA

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)