### PR TITLE
fix: updated syntax to match other filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,14 @@ Unreleased
 ----------
 .. scriv-insert-here
 
+[3.4.1] - 2026-05-26
+
+Changed
+~~~~~
+
+* Update ``InstructorDashboardTabsRequested`` to match ``run_filter`` return pattern of other filters. by @holaontiveros
+
+
 [3.4.0] - 2026-05-07
 
 Added

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1339,7 +1339,7 @@ class InstructorDashboardTabsRequested(OpenEdxPublicFilter):
         tabs: list,
         user: Any,
         course_key: CourseKey
-    ) -> list | None:
+    ) -> tuple[list | None, Any | None, CourseKey | None]:
         """
         Process the tabs list using the configured pipeline steps to modify instructor dashboard tabs.
         Arguments:
@@ -1347,14 +1347,17 @@ class InstructorDashboardTabsRequested(OpenEdxPublicFilter):
             user (User): Django User object (usually an instructor or staff member).
             course_key (CourseKey): Course key for the instructor dashboard.
         Returns:
-            list | None: Tab dictionaries, possibly modified by pipeline steps, or None if not provided.
+            tuple[list | None, Any | None, CourseKey | None]:
+                - list | None: Tab dictionaries, possibly modified by pipeline steps, or None if not provided.
+                - Any | None: User object, possibly modified by pipeline steps, or None if not provided.
+                - CourseKey | None: Course key, possibly modified by pipeline steps, or None if not provided.
         """
         data = super().run_pipeline(
             tabs=tabs,
             user=user,
             course_key=course_key
         )
-        return data.get("tabs")
+        return data.get("tabs"), data.get("user"), data.get("course_key")
 
 
 class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -897,11 +897,13 @@ class TestInstructorDashboardTabsRequested(TestCase):
 
         with patch("openedx_filters.tooling.OpenEdxPublicFilter.run_pipeline") as mock_run_pipeline:
             mock_run_pipeline.return_value = {"tabs": tabs, "user": user, "course_key": course_key}
-            result_tabs = InstructorDashboardTabsRequested.run_filter(
+            result_tabs, result_user, result_course_key = InstructorDashboardTabsRequested.run_filter(
                 tabs=tabs, user=user, course_key=course_key
             )
 
         self.assertEqual(result_tabs, tabs)
+        self.assertEqual(result_user, user)
+        self.assertEqual(result_course_key, course_key)
 
     def test_filter_type(self):
         """Test that the filter type is properly set."""
@@ -930,11 +932,13 @@ class TestInstructorDashboardTabsRequested(TestCase):
             mock_run_pipeline.return_value = {
                 "tabs": modified_tabs, "user": user, "course_key": course_key
             }
-            result_tabs = InstructorDashboardTabsRequested.run_filter(
+            result_tabs, result_user, result_course_key = InstructorDashboardTabsRequested.run_filter(
                 tabs=tabs, user=user, course_key=course_key
             )
 
         self.assertEqual(result_tabs, modified_tabs)
+        self.assertEqual(result_user, user)
+        self.assertEqual(result_course_key, course_key)
 
     @data(
         (


### PR DESCRIPTION
## Description

Previous `InstructorDashboardTabsRequested` filter didn't follow 100% the usual pattern of how the run_filter returned arguments, this updates that now the run_filter returns all the arguments that it received.

## Supporting information

This originated on the conversation of this filter being implemented here: https://github.com/openedx/openedx-platform/pull/38499#discussion_r3306316721

## Deadline

None

## Other information

This is virtually the same as before, it only returns two more items in the tuple to match other run_filter patterns, nothing depends on it more than the code that goes will consume it that will algo be updated after this is merged.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [x] Changelog entry added using scriv with short description of the change
- [x] Documentation updated (not only docstrings)
- [x] Code dependencies reviewed
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Trigger the release workflow to create a new GitHub release.
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
