### PR TITLE
feat: DiscountEligibilityCheckRequested filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,15 @@ Unreleased
 ----------
 .. scriv-insert-here
 
-.. _changelog-3.5.0:
+.. _changelog-3.7.0:
+
+[3.7.0] - 2026-06-22
+---------------------
+
+Added
+~~~~~
+
+* Added new ``DiscountEligibilityCheckRequested`` filter
 
 [3.6.0] - 2026-06-18
 --------------------

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1838,3 +1838,55 @@ class CoursewareAccessChecksRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(user=user, course_key=course_key)
         return data["user"], data["course_key"]
+
+
+class DiscountEligibilityCheckRequested(OpenEdxPublicFilter):
+    """
+    Filter used to allow plugins to mark a user as ineligible for a course discount.
+
+    Purpose:
+        This filter is triggered during discount applicability checks, just before the
+        final eligibility decision is returned to the caller. Pipeline steps may raise
+        ``DiscountIneligible`` to exclude a user from receiving a discount.
+
+    Filter Type:
+        org.openedx.learning.discount.eligibility.check.requested.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: openedx/features/discounts/applicability.py
+        - Function or Method: can_receive_discount, can_show_streak_discount_coupon
+    """
+
+    filter_type = "org.openedx.learning.discount.eligibility.check.requested.v1"
+
+    class DiscountIneligible(OpenEdxFilterException):
+        """
+        Raised by a pipeline step to indicate user is ineligible for discounts
+        """
+
+    @classmethod
+    def run_filter(
+        cls,
+        user: Any,
+        course_key: CourseKey,
+    ) -> tuple[Any, CourseKey]:
+        """
+        Process the inputs using the configured pipeline steps.
+
+        Arguments:
+            user (User): the Django User being checked for discount eligibility.
+            course_key (CourseKey or course object): identifies the course.
+
+        Returns:
+            tuple[User, CourseKey, bool]:
+                - User: the Django User object (unchanged).
+                - CourseKey: the course key (unchanged).
+                - bool: the (possibly overridden) eligibility flag.
+
+        Raises:
+            DiscountIneligible: when a pipeline step determines the user is
+                not eligible for a discount and halts further processing.
+        """
+        data = super().run_pipeline(user=user, course_key=course_key)
+        return data["user"], data["course_key"]

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -29,6 +29,7 @@ from openedx_filters.learning.filters import (
     CoursewareAccessChecksRequested,
     CoursewareViewStarted,
     DashboardRenderStarted,
+    DiscountEligibilityCheckRequested,
     GradeEventContextRequested,
     IDVPageURLRequested,
     InstructorDashboardRenderStarted,
@@ -1099,3 +1100,43 @@ class TestCoursewareAccessChecksRequested(TestCase):
         assert exc.error_code == "some_code"
         assert exc.developer_message == "developer message"
         assert exc.user_message == "user message"
+
+
+class TestDiscountEligibilityCheckRequestedFilter(TestCase):
+    """
+    Tests for the DiscountEligibilityCheckRequested filter.
+    """
+
+    def test_filter_type(self):
+        self.assertEqual(
+            DiscountEligibilityCheckRequested.filter_type,
+            "org.openedx.learning.discount.eligibility.check.requested.v1",
+        )
+
+    def test_run_filter_passes_through_user_and_course_key(self):
+        user = Mock()
+        course_key = Mock()
+
+        returned_user, returned_course_key = (
+            DiscountEligibilityCheckRequested.run_filter(user, course_key)
+        )
+
+        self.assertIs(returned_user, user)
+        self.assertIs(returned_course_key, course_key)
+
+    def test_run_filter_raises_discount_ineligible_from_pipeline(self):
+        user = Mock()
+        course_key = Mock()
+        exc = DiscountEligibilityCheckRequested.DiscountIneligible("Enterprise contract prohibits discount.")
+
+        with patch(
+            "openedx_filters.tooling.OpenEdxPublicFilter.run_pipeline",
+            side_effect=exc,
+        ):
+            with self.assertRaises(DiscountEligibilityCheckRequested.DiscountIneligible):
+                DiscountEligibilityCheckRequested.run_filter(user, course_key)
+
+    def test_discount_ineligible_exception_stores_message(self):
+        exc = DiscountEligibilityCheckRequested.DiscountIneligible("Enterprise contract prohibits discount.")
+
+        self.assertEqual(exc.message, "Enterprise contract prohibits discount.")


### PR DESCRIPTION
Clone of https://github.com/openedx/openedx-filters/pull/335 for [ENT-11564](https://2u-internal.atlassian.net/browse/ENT-11564)

Adds a new DiscountEligibilityCheckRequested filter to the learning subdomain, enabling plugins to mark users as ineligible for LMS-controlled course discounts without coupling the core platform to enterprise-specific logic.

Co-Authored-By: Claude Sonnet 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)