### PR TITLE
feat: add CourseModePriceRequested filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,14 @@ Unreleased
 
 .. _changelog-3.7.0:
 
+[3.8.0] - 2026-07-07
+---------------------
+
+Added
+~~~~~
+
+* Added new ``CourseModePriceRequested`` filter
+
 [3.7.0] - 2026-06-22
 ---------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1095,14 +1095,14 @@ class VerticalBlockRenderCompleted(OpenEdxPublicFilter):
         Process the inputs using the configured pipeline steps to modify the rendering of a vertical block.
 
         Arguments:
-            block (VerticalBlock): The VeriticalBlock instance which is being rendered.
+            block (VerticalBlock): The VerticalBlock instance which is being rendered.
             fragment (web_fragments.Fragment): The web-fragment containing the rendered content of VerticalBlock.
             context (dict): rendering context values like is_mobile_app, show_title..etc.
             view (str): the rendering view. Can be either 'student_view', or 'public_view'.
 
         Returns:
-            tuple[VeticalBlock, web_fragments.Fragment, dict, str]:
-                - VerticalBlock: The VeriticalBlock instance which is being rendered.
+            tuple[VerticalBlock, web_fragments.Fragment, dict, str]:
+                - VerticalBlock: The VerticalBlock instance which is being rendered.
                 - web_fragments.Fragment: The web-fragment containing the rendered content of VerticalBlock.
                 - dict: rendering context values like is_mobile_app, show_title..etc.
                 - str: the rendering view. Can be either 'student_view', or 'public_view'.
@@ -1890,3 +1890,49 @@ class DiscountEligibilityCheckRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(user=user, course_key=course_key)
         return data["user"], data["course_key"]
+
+
+class CourseModePriceRequested(OpenEdxPublicFilter):
+    """
+    Filter used to determine the price a learner should be charged for a course mode.
+
+    Purpose:
+        This filter is triggered when the price for a course mode checkout needs to be
+        calculated. Pipeline steps can adjust the price and apply discounts, like
+        enterprise-negotiated pricing.
+
+    Filter Type:
+        org.openedx.learning.course_mode.price.requested.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: common/djangoapps/course_modes/views.py
+        - Function or Method: ChooseModeView.get
+    """
+
+    filter_type = "org.openedx.learning.course_mode.price.requested.v1"
+
+    @classmethod
+    def run_filter(
+        cls,
+        user: Any,
+        course_mode_data: Any,
+        price: int
+    ) -> tuple[Any, Any, int]:
+        """
+        Process and possibly adjust the price through the configured pipeline steps.
+
+        Arguments:
+            user (Any): The Django User object.
+            course_mode_data (Any): The selected course mode object.
+            price (int): Price of the course mode in whole currency units (e.g., dollars, not cents).
+                         The currency is stored on the course_mode_data object (course_mode_data.currency).
+        Returns:
+            tuple[Any, Any, int]:
+                - user (Any): django User object (unchanged)
+                - course_mode_data (Any): The selected course mode object (unchanged)
+                - price (int): Price (possibly adjusted)
+
+        """
+        data = super().run_pipeline(user=user, course_mode_data=course_mode_data, price=price)
+        return data["user"], data["course_mode_data"], data["price"]

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -23,6 +23,7 @@ from openedx_filters.learning.filters import (
     CourseEnrollmentStarted,
     CourseEnrollmentViewStarted,
     CourseHomeUrlCreationStarted,
+    CourseModePriceRequested,
     CourseRunAPIRenderStarted,
     CourseStartDateValidationFailed,
     CourseUnenrollmentStarted,
@@ -1121,8 +1122,8 @@ class TestDiscountEligibilityCheckRequestedFilter(TestCase):
             DiscountEligibilityCheckRequested.run_filter(user, course_key)
         )
 
-        self.assertIs(returned_user, user)
-        self.assertIs(returned_course_key, course_key)
+        assert returned_user == user
+        assert returned_course_key == course_key
 
     def test_run_filter_raises_discount_ineligible_from_pipeline(self):
         user = Mock()
@@ -1139,4 +1140,31 @@ class TestDiscountEligibilityCheckRequestedFilter(TestCase):
     def test_discount_ineligible_exception_stores_message(self):
         exc = DiscountEligibilityCheckRequested.DiscountIneligible("Enterprise contract prohibits discount.")
 
-        self.assertEqual(exc.message, "Enterprise contract prohibits discount.")
+        assert exc.message == "Enterprise contract prohibits discount."
+
+
+class TestCourseModeFilters(TestCase):
+    """
+    Test class to verify standard behavior of the CourseModePriceRequested filter.
+    """
+
+    def test_course_mode_price_requested(self):
+        """
+        Test CourseModePriceRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return the (possibly discounted) price.
+        """
+        user = Mock()
+        course_mode_data = Mock()
+        price = 100
+        assert CourseModePriceRequested.filter_type == "org.openedx.learning.course_mode.price.requested.v1"
+
+        result_user, result_course_mode_data, result_price = CourseModePriceRequested.run_filter(
+            user, course_mode_data, price
+        )
+
+        assert user == result_user
+        assert course_mode_data == result_course_mode_data
+        assert price == result_price


### PR DESCRIPTION
<!--

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

Fore more details on the Hooks Extension Framework contribution process, see:

https://docs.openedx.org/en/latest/developers/concepts/hooks_extension_framework.html

-->

## Description

This new filter determines the price a learner should be charged based upon their course mode. It has two related PRs that show the full implementation and how it is tested (see below). 

This ticket is split from https://github.com/openedx/openedx-filters/pull/338, please reference for previous PR comments. 

## Supporting information

https://2u-internal.atlassian.net/browse/ENT-11573
https://github.com/edx/edx-platform/pull/365
https://github.com/openedx/edx-enterprise/pull/2556

## Testing instructions

Testing instruction in the edx-enterprise PR!

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [x] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [x] Changelog entry added using scriv with short description of the change
- [x] Documentation updated (not only docstrings)
- [x] Code dependencies reviewed
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Trigger the release workflow to create a new GitHub release.
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
