### PR TITLE
feat: add AccountActivationEmailComposed and AccountActivationCompleted filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,14 @@ Added
     auth provider configuration that the form filters pass to pipeline steps.
   * ``RunningPipeline`` - authentication pipeline state.
 
+[3.9.0] - 2026-07-22
+---------------------
+
+Added
+~~~~~
+
+* Added new ``AccountActivationEmailComposed`` and ``AccountActivationCompleted`` filters
+
 [3.8.0] - 2026-07-07
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,16 @@ Unreleased
 ----------
 .. scriv-insert-here
 
-.. _changelog-3.9.0:
+
+.. _changelog-3.10.0:
+
+[3.10.0] - 2026-08-10
+---------------------
+
+Added
+~~~~~
+
+* Added new ``AccountActivationEmailComposed`` and ``AccountActivationCompleted`` filters
 
 [3.9.0] - 2026-08-04
 --------------------
@@ -59,14 +68,6 @@ Added
   * ``ProviderConfigProtocol`` - declares the minimal surface of the third-party
     auth provider configuration that the form filters pass to pipeline steps.
   * ``RunningPipeline`` - authentication pipeline state.
-
-[3.9.0] - 2026-07-22
----------------------
-
-Added
-~~~~~
-
-* Added new ``AccountActivationEmailComposed`` and ``AccountActivationCompleted`` filters
 
 [3.8.0] - 2026-07-07
 ---------------------

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.9.0"
+__version__ = "3.10.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1621,6 +1621,83 @@ class AccountSettingsReadOnlyFieldsRequested(OpenEdxPublicFilter):
         return (data["readonly_fields"], data["user"])
 
 
+class AccountActivationEmailComposed(OpenEdxPublicFilter):
+    """
+    Filter used to modify the activation email context before it is sent.
+
+    Purpose:
+        This filter is triggered when the account activation email is composed, just before the
+        message is personalized and sent, allowing the filter to act on the message context.
+
+    Filter Type:
+        org.openedx.learning.account.activation.email.compose.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: common/djangoapps/student/views/management.py
+        - Function or Method: compose_activation_email
+    """
+
+    filter_type = "org.openedx.learning.account.activation.email.compose.v1"
+
+    @classmethod
+    def run_filter(cls, user: Any, message_context: dict) -> tuple[Any, dict | None]:
+        """
+        Process the user and message_context using the configured pipeline steps to modify the
+        activation email context.
+
+        Arguments:
+            user (User): Django User object the activation email is being composed for.
+            message_context (dict): context dictionary used to render the activation email.
+
+        Returns:
+            tuple[User, dict]:
+                - User: Django User object.
+                - dict: context dictionary used to render the activation email, possibly modified.
+        """
+        data = super().run_pipeline(user=user, message_context=message_context)
+        return data.get("user"), data.get("message_context")
+
+
+class AccountActivationCompleted(OpenEdxPublicFilter):
+    """
+    Filter used to modify the redirect destination after a user's account is activated.
+
+    Purpose:
+        This filter is triggered when a user's account activation completes, just before the
+        post-activation redirect is issued, allowing the filter to act on the redirect URL.
+
+    Filter Type:
+        org.openedx.learning.account.activation.completed.v1
+
+    Trigger:
+        - Repository: openedx/openedx-platform
+        - Path: common/djangoapps/student/views/management.py
+        - Function or Method: activate_account
+    """
+
+    filter_type = "org.openedx.learning.account.activation.completed.v1"
+
+    @classmethod
+    def run_filter(cls, user: Any, redirect_url: str) -> tuple[Any, str | None]:
+        """
+        Process the user and redirect_url using the configured pipeline steps to modify the
+        post-activation redirect.
+
+        Arguments:
+            user (User): Django User object whose account was just activated.
+            redirect_url (str): URL the user would be redirected to, empty string if none.
+
+        Returns:
+            tuple[User, str]:
+                - User: Django User object.
+                - str: URL to redirect to, possibly modified. Falsy values fall back to the
+                    dashboard.
+        """
+        data = super().run_pipeline(user=user, redirect_url=redirect_url)
+        return data.get("user"), data.get("redirect_url")
+
+
 class GradeEventContextRequested(OpenEdxPublicFilter):
     """
     Filter used to enrich the context for grade events.

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1641,7 +1641,7 @@ class AccountActivationEmailComposed(OpenEdxPublicFilter):
     filter_type = "org.openedx.learning.account.activation.email.compose.v1"
 
     @classmethod
-    def run_filter(cls, user: Any, message_context: dict) -> tuple[Any, dict | None]:
+    def run_filter(cls, user: Any, message_context: dict[str, Any]) -> tuple[Any, dict[str, Any] | None]:
         """
         Process the user and message_context using the configured pipeline steps to modify the
         activation email context.
@@ -1686,13 +1686,15 @@ class AccountActivationCompleted(OpenEdxPublicFilter):
 
         Arguments:
             user (User): Django User object whose account was just activated.
-            redirect_url (str): URL the user would be redirected to, empty string if none.
+            redirect_url (str): URL the user would be redirected to, empty string to trigger
+                the LMS default redirect.
 
         Returns:
-            tuple[User, str]:
+            tuple[User, str | None]:
                 - User: Django User object.
-                - str: URL to redirect to, possibly modified. Falsy values fall back to the
-                    dashboard.
+                - str | None: URL to redirect to, possibly modified. A falsy value (empty
+                    string or None) causes the LMS to fall back to its default redirect
+                    (currently the dashboard).
         """
         data = super().run_pipeline(user=user, redirect_url=redirect_url)
         return data.get("user"), data.get("redirect_url")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -10,6 +10,8 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
 from openedx_filters.learning.filters import (
+    AccountActivationCompleted,
+    AccountActivationEmailComposed,
     AccountSettingsReadOnlyFieldsRequested,
     AccountSettingsRenderStarted,
     CertificateCreationRequested,
@@ -896,6 +898,58 @@ class TestAccountSettingsReadOnlyFieldsRequestedFilter(TestCase):
     def test_filter_type(self):
         filter_type = "org.openedx.learning.account.settings.read_only_fields.requested.v1"
         assert AccountSettingsReadOnlyFieldsRequested.filter_type == filter_type
+
+
+class TestAccountActivationEmailComposedFilter(TestCase):
+    """
+    Tests for the AccountActivationEmailComposed filter.
+    """
+
+    def test_filter_type(self):
+        assert (
+            AccountActivationEmailComposed.filter_type
+            == "org.openedx.learning.account.activation.email.compose.v1"
+        )
+
+    def test_run_filter_returns_inputs_unchanged_when_no_pipeline(self):
+        """
+        When no pipeline steps are configured, run_filter returns the original inputs unchanged.
+        """
+        user = Mock()
+        message_context = {"key": "abc123"}
+
+        result_user, result_context = AccountActivationEmailComposed.run_filter(
+            user=user, message_context=message_context
+        )
+
+        assert result_user == user
+        assert result_context == message_context
+
+
+class TestAccountActivationCompletedFilter(TestCase):
+    """
+    Tests for the AccountActivationCompleted filter.
+    """
+
+    def test_filter_type(self):
+        assert (
+            AccountActivationCompleted.filter_type
+            == "org.openedx.learning.account.activation.completed.v1"
+        )
+
+    def test_run_filter_returns_inputs_unchanged_when_no_pipeline(self):
+        """
+        When no pipeline steps are configured, run_filter returns the original inputs unchanged.
+        """
+        user = Mock()
+        redirect_url = "https://example.com/next"
+
+        result_user, result_redirect_url = AccountActivationCompleted.run_filter(
+            user=user, redirect_url=redirect_url
+        )
+
+        assert result_user == user
+        assert result_redirect_url == redirect_url
 
 
 @ddt


### PR DESCRIPTION
⚠️ This PR superseded by https://github.com/openedx/openedx-filters/pull/391

---


[ENT-11816](https://2u-internal.atlassian.net/browse/ENT-11816)

This pull request introduces two new public filters for account activation events and updates the package version to 3.9.0. It also includes comprehensive tests for the new filters and documents the changes in the changelog.

**New Account Activation Filters:**

* Added `AccountActivationEmailComposed` filter to allow modification of the activation email context before it is sent. (`openedx_filters/learning/filters.py`, `openedx_filters/learning/tests/test_filters.py`) [[1]](diffhunk://#diff-0c79edd111d62405dc0829ac0b0b971c73b410de87c0133a7190b3de08b40ed9R1624-R1700) [[2]](diffhunk://#diff-efdd331dfcd8556cb1fc7654400d452c38493d4527ddb77297fef21659b9dab4R13-R14) [[3]](diffhunk://#diff-efdd331dfcd8556cb1fc7654400d452c38493d4527ddb77297fef21659b9dab4R903-R954)
* Added `AccountActivationCompleted` filter to allow modification of the redirect URL after account activation. (`openedx_filters/learning/filters.py`, `openedx_filters/learning/tests/test_filters.py`) [[1]](diffhunk://#diff-0c79edd111d62405dc0829ac0b0b971c73b410de87c0133a7190b3de08b40ed9R1624-R1700) [[2]](diffhunk://#diff-efdd331dfcd8556cb1fc7654400d452c38493d4527ddb77297fef21659b9dab4R13-R14) [[3]](diffhunk://#diff-efdd331dfcd8556cb1fc7654400d452c38493d4527ddb77297fef21659b9dab4R903-R954)

**Testing:**

* Added unit tests for both new filters to verify their filter types and default behavior when no pipeline steps are configured. (`openedx_filters/learning/tests/test_filters.py`)