### PR TITLE
chore: upgrade python requirements and fix isort invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ quality: ## check coding style with pycodestyle and pylint
 	mypy
 	pycodestyle openedx_filters  *.py
 	ruff check openedx_filters *.py
-	isort --check-only --diff --recursive test_utils openedx_filters *.py test_settings.py
+	isort --check-only --diff test_utils openedx_filters *.py
 	python setup.py bdist_wheel
 	twine check dist/*
 	make selfcheck

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
-django==5.2.14
+django==5.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -16,11 +16,11 @@ edx-opaque-keys[django]==4.0.0
     # via -r requirements/base.in
 pymongo==4.17.0
     # via edx-opaque-keys
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
-stevedore==5.7.0
+stevedore==5.9.1
     # via edx-opaque-keys
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via edx-opaque-keys
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,37 +4,38 @@
 #
 #    make upgrade
 #
-cachetools==7.1.1
+cachetools==7.1.8
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
-filelock==3.29.0
+filelock==3.32.5
     # via
     #   python-discovery
     #   tox
     #   virtualenv
-packaging==26.2
+packaging==26.3
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.9.6
+platformdirs==4.11.5
     # via
-    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
-pyproject-api==1.10.0
+pyproject-api==1.11.0
     # via tox
-python-discovery==1.3.0
+python-discovery==1.6.0
     # via
     #   tox
     #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.53.1
+tox==4.61.2
     # via -r requirements/ci.in
-virtualenv==21.3.1
+typing-extensions==4.16.0
+    # via tox
+virtualenv==21.7.7
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/quality.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.8.0
     # via
     #   -r requirements/quality.txt
     #   mypy
@@ -19,29 +19,25 @@ astroid==4.0.4
     #   pylint-celery
 attrs==26.1.0
     # via scriv
-build==1.5.0
+build==1.6.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.1.1
+cachetools==7.1.8
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2026.4.22
+certifi==2026.7.22
     # via
     #   -r requirements/quality.txt
     #   requests
-cffi==2.0.0
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
-chardet==7.4.3
+chardet==7.6.0
     # via diff-cover
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.3.3
+click==8.5.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -63,35 +59,31 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.14.0
+coverage[toml]==7.16.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==48.0.0
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 ddt==1.7.2
     # via -r requirements/quality.txt
-diff-cover==10.2.0
+diff-cover==10.5.1
     # via -r requirements/dev.in
 dill==0.4.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.4.0
+distlib==0.4.3
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==5.2.14
+django==5.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.1.0
     # via -r requirements/quality.txt
-django-stubs-ext==6.0.4
+django-stubs-ext==6.1.0
     # via
     #   -r requirements/quality.txt
     #   django-stubs
@@ -99,15 +91,15 @@ dnspython==2.8.0
     # via
     #   -r requirements/quality.txt
     #   pymongo
-docutils==0.22.4
+docutils==0.23
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-lint==6.1.0
+edx-lint==6.2.0
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==4.0.0
     # via -r requirements/quality.txt
-filelock==3.29.0
+filelock==3.32.5
     # via
     #   -r requirements/ci.txt
     #   python-discovery
@@ -117,7 +109,7 @@ id==1.6.1
     # via
     #   -r requirements/quality.txt
     #   twine
-idna==3.14
+idna==3.19
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -125,7 +117,7 @@ iniconfig==2.3.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==8.0.1
+isort==9.0.1
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -137,15 +129,10 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.9.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/quality.txt
@@ -156,7 +143,7 @@ keyring==25.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
-librt==0.11.0
+librt==0.15.0
     # via
     #   -r requirements/quality.txt
     #   mypy
@@ -177,22 +164,23 @@ mdurl==0.1.2
     # via
     #   -r requirements/quality.txt
     #   markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-mypy==2.0.0
+mypy==2.3.1
     # via -r requirements/quality.txt
 mypy-extensions==1.1.0
     # via
     #   -r requirements/quality.txt
+    #   isort
     #   mypy
-nh3==0.3.5
+nh3==0.3.7
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-packaging==26.2
+packaging==26.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -207,14 +195,13 @@ pathspec==1.1.1
     # via
     #   -r requirements/quality.txt
     #   mypy
-pip-tools==7.5.3
+pip-tools==7.6.1
     # via -r requirements/pip-tools.txt
-platformdirs==4.9.6
+platformdirs==4.11.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
-    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -227,18 +214,14 @@ pluggy==1.6.0
     #   tox
 pycodestyle==2.14.0
     # via -r requirements/quality.txt
-pycparser==3.0
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
-pygments==2.20.0
+pygments==2.21.0
     # via
     #   -r requirements/quality.txt
     #   diff-cover
     #   pytest
     #   readme-renderer
     #   rich
-pylint==4.0.5
+pylint==4.0.8
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -249,7 +232,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -262,7 +245,7 @@ pymongo==4.17.0
     # via
     #   -r requirements/quality.txt
     #   edx-opaque-keys
-pyproject-api==1.10.0
+pyproject-api==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -271,16 +254,16 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==7.1.0
     # via -r requirements/quality.txt
-pytest-django==4.12.0
+pytest-django==4.14.0
     # via -r requirements/quality.txt
-python-discovery==1.3.0
+python-discovery==1.6.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -293,11 +276,11 @@ pyyaml==6.0.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-readme-renderer==44.0
+readme-renderer==46.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/quality.txt
     #   requests-toolbelt
@@ -315,23 +298,19 @@ rich==15.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-ruff==0.15.12
+ruff==0.16.5
     # via -r requirements/quality.txt
 scriv==1.8.0
     # via -r requirements/dev.in
-secretstorage==3.5.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.17.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==5.7.0
+stevedore==5.9.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -344,37 +323,39 @@ tomli-w==1.2.0
     # via
     #   -r requirements/ci.txt
     #   tox
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via
     #   -r requirements/quality.txt
     #   edx-lint
     #   pylint
-tox==4.53.1
+tox==4.61.2
     # via -r requirements/ci.txt
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/quality.txt
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260815
     # via
     #   -r requirements/quality.txt
     #   django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   django-stubs
     #   django-stubs-ext
     #   edx-opaque-keys
     #   mypy
+    #   tox
 urllib3==2.7.0
     # via
     #   -r requirements/quality.txt
     #   id
     #   requests
     #   twine
-virtualenv==21.3.1
+virtualenv==21.7.7
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.47.0
+wheel==0.48.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,15 +8,15 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   starlette
     #   watchfiles
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/test.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.8.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -24,17 +24,15 @@ babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
     # via pydata-sphinx-theme
-build==1.5.0
+build==1.6.0
     # via -r requirements/doc.in
-certifi==2026.4.22
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
-    # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
-click==8.3.3
+click==8.5.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -43,23 +41,21 @@ code-annotations==3.0.0
     # via -r requirements/test.txt
 colorama==0.4.6
     # via sphinx-autobuild
-coverage[toml]==7.14.0
+coverage[toml]==7.16.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-django==5.2.14
+django==5.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.1.0
     # via -r requirements/test.txt
-django-stubs-ext==6.0.4
+django-stubs-ext==6.1.0
     # via
     #   -r requirements/test.txt
     #   django-stubs
@@ -72,6 +68,7 @@ doc8==2.0.0
 docutils==0.21.2
     # via
     #   doc8
+    #   myst-parser
     #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
@@ -82,11 +79,11 @@ h11==0.16.0
     # via uvicorn
 id==1.6.1
     # via twine
-idna==3.14
+idna==3.19
     # via
     #   anyio
     #   requests
-imagesize==2.0.0
+imagesize==2.0.1
     # via sphinx
 iniconfig==2.3.0
     # via
@@ -96,21 +93,19 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   myst-parser
+    #   pydata-sphinx-theme
     #   sphinx
     #   sphinxcontrib-mermaid
 keyring==25.7.0
     # via twine
-librt==0.11.0
+librt==0.15.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -127,11 +122,11 @@ mdit-py-plugins==0.6.1
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==2.0.0
+mypy==2.3.1
     # via -r requirements/test.txt
 mypy-extensions==1.1.0
     # via
@@ -139,9 +134,9 @@ mypy-extensions==1.1.0
     #   mypy
 myst-parser==5.1.0
     # via -r requirements/doc.in
-nh3==0.3.5
+nh3==0.3.7
     # via readme-renderer
-packaging==26.2
+packaging==26.3
     # via
     #   -r requirements/test.txt
     #   build
@@ -157,11 +152,9 @@ pluggy==1.6.0
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
-pycparser==3.0
-    # via cffi
-pydata-sphinx-theme==0.16.1
+pydata-sphinx-theme==0.20.0
     # via sphinx-book-theme
-pygments==2.20.0
+pygments==2.21.0
     # via
     #   -r requirements/test.txt
     #   accessible-pygments
@@ -177,14 +170,14 @@ pymongo==4.17.0
     #   edx-opaque-keys
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==7.1.0
     # via -r requirements/test.txt
-pytest-django==4.12.0
+pytest-django==4.14.0
     # via -r requirements/test.txt
 python-slugify==8.0.4
     # via
@@ -194,11 +187,13 @@ pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   myst-parser
     #   sphinxcontrib-mermaid
-readme-renderer==44.0
+readme-renderer==46.0
     # via twine
-requests==2.33.1
+requests==2.34.2
     # via
+    #   pydata-sphinx-theme
     #   requests-toolbelt
     #   sphinx
     #   twine
@@ -212,15 +207,14 @@ rich==15.0.0
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-secretstorage==3.5.0
-    # via keyring
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
-soupsieve==2.8.3
+soupsieve==2.9.2
     # via beautifulsoup4
 sphinx==9.1.0
     # via
     #   -r requirements/doc.in
+    #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx-autobuild
     #   sphinx-book-theme
@@ -228,7 +222,7 @@ sphinx==9.1.0
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2025.8.25
     # via -r requirements/doc.in
-sphinx-book-theme==1.2.0
+sphinx-book-theme==1.4.0
     # via -r requirements/doc.in
 sphinx-copybutton==0.5.2
     # via -r requirements/doc.in
@@ -240,19 +234,19 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-mermaid==2.0.2
+sphinxcontrib-mermaid==2.1.0
     # via -r requirements/doc.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   -r requirements/test.txt
     #   django
-starlette==1.0.0
+starlette==1.6.0
     # via sphinx-autobuild
-stevedore==5.7.0
+stevedore==5.9.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -262,13 +256,13 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/doc.in
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260815
     # via
     #   -r requirements/test.txt
     #   django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/test.txt
     #   anyio
@@ -277,16 +271,15 @@ typing-extensions==4.15.0
     #   django-stubs-ext
     #   edx-opaque-keys
     #   mypy
-    #   pydata-sphinx-theme
     #   starlette
 urllib3==2.7.0
     # via
     #   id
     #   requests
     #   twine
-uvicorn==0.46.0
+uvicorn==0.52.4
     # via sphinx-autobuild
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via sphinx-autobuild
-websockets==16.0
+websockets==17.1
     # via sphinx-autobuild

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,21 +4,21 @@
 #
 #    make upgrade
 #
-build==1.5.0
+build==1.6.0
     # via pip-tools
-click==8.3.3
+click==8.5.0
     # via pip-tools
-packaging==26.2
+packaging==26.3
     # via
     #   build
     #   wheel
-pip-tools==7.5.3
+pip-tools==7.6.1
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.47.0
+wheel==0.48.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,15 @@
 #
 #    make upgrade
 #
-packaging==26.2
+packaging==26.3
     # via wheel
-wheel==0.47.0
+wheel==0.48.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.1
-    # via -r requirements/pip.in
-setuptools==82.0.1
+pip==26.2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in
+setuptools==84.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/test.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.8.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -16,13 +16,11 @@ astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-certifi==2026.4.22
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
-    # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
-click==8.3.3
+click==8.5.0
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -34,25 +32,23 @@ code-annotations==3.0.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.14.0
+coverage[toml]==7.16.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.4.1
     # via pylint
-django==5.2.14
+django==5.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.1.0
     # via -r requirements/test.txt
-django-stubs-ext==6.0.4
+django-stubs-ext==6.1.0
     # via
     #   -r requirements/test.txt
     #   django-stubs
@@ -60,21 +56,21 @@ dnspython==2.8.0
     # via
     #   -r requirements/test.txt
     #   pymongo
-docutils==0.22.4
+docutils==0.23
     # via readme-renderer
-edx-lint==6.1.0
+edx-lint==6.2.0
     # via -r requirements/quality.in
 edx-opaque-keys[django]==4.0.0
     # via -r requirements/test.txt
 id==1.6.1
     # via twine
-idna==3.14
+idna==3.19
     # via requests
 iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==8.0.1
+isort==9.0.1
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -82,19 +78,15 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
 keyring==25.7.0
     # via twine
-librt==0.11.0
+librt==0.15.0
     # via
     #   -r requirements/test.txt
     #   mypy
@@ -108,21 +100,22 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==2.0.0
+mypy==2.3.1
     # via
     #   -r requirements/quality.in
     #   -r requirements/test.txt
 mypy-extensions==1.1.0
     # via
     #   -r requirements/test.txt
+    #   isort
     #   mypy
-nh3==0.3.5
+nh3==0.3.7
     # via readme-renderer
-packaging==26.2
+packaging==26.3
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -131,7 +124,7 @@ pathspec==1.1.1
     # via
     #   -r requirements/test.txt
     #   mypy
-platformdirs==4.9.6
+platformdirs==4.11.5
     # via pylint
 pluggy==1.6.0
     # via
@@ -140,15 +133,13 @@ pluggy==1.6.0
     #   pytest-cov
 pycodestyle==2.14.0
     # via -r requirements/quality.in
-pycparser==3.0
-    # via cffi
-pygments==2.20.0
+pygments==2.21.0
     # via
     #   -r requirements/test.txt
     #   pytest
     #   readme-renderer
     #   rich
-pylint==4.0.5
+pylint==4.0.8
     # via
     #   edx-lint
     #   pylint-celery
@@ -156,7 +147,7 @@ pylint==4.0.5
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
@@ -166,14 +157,14 @@ pymongo==4.17.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==7.1.0
     # via -r requirements/test.txt
-pytest-django==4.12.0
+pytest-django==4.14.0
     # via -r requirements/test.txt
 python-slugify==8.0.4
     # via
@@ -183,9 +174,9 @@ pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==44.0
+readme-renderer==46.0
     # via twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   requests-toolbelt
     #   twine
@@ -195,17 +186,15 @@ rfc3986==2.0.0
     # via twine
 rich==15.0.0
     # via twine
-ruff==0.15.12
+ruff==0.16.5
     # via -r requirements/quality.in
-secretstorage==3.5.0
-    # via keyring
 six==1.17.0
     # via edx-lint
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.7.0
+stevedore==5.9.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -214,17 +203,17 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via
     #   edx-lint
     #   pylint
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/quality.in
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260815
     # via
     #   -r requirements/test.txt
     #   django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/test.txt
     #   django-stubs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   -r requirements/base.txt
     #   django
-ast-serialize==0.3.0
+ast-serialize==0.8.0
     # via mypy
-click==8.3.3
+click==8.5.0
     # via code-annotations
 code-annotations==3.0.0
     # via -r requirements/test.in
-coverage[toml]==7.14.0
+coverage[toml]==7.16.0
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
@@ -23,9 +23,9 @@ ddt==1.7.2
     #   -r requirements/base.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==6.0.4
+django-stubs==6.1.0
     # via -r requirements/test.in
-django-stubs-ext==6.0.4
+django-stubs-ext==6.1.0
     # via django-stubs
 dnspython==2.8.0
     # via
@@ -37,15 +37,15 @@ iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
     # via code-annotations
-librt==0.11.0
+librt==0.15.0
     # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==2.0.0
+mypy==2.3.1
     # via -r requirements/test.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==26.2
+packaging==26.3
     # via pytest
 pathspec==1.1.1
     # via mypy
@@ -53,38 +53,38 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pygments==2.20.0
+pygments==2.21.0
     # via pytest
 pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   pytest-cov
     #   pytest-django
 pytest-cov==7.1.0
     # via -r requirements/test.in
-pytest-django==4.12.0
+pytest-django==4.14.0
     # via -r requirements/test.in
 python-slugify==8.0.4
     # via code-annotations
 pyyaml==6.0.3
     # via code-annotations
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.7.0
+stevedore==5.9.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260815
     # via django-stubs
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements/base.txt
     #   django-stubs


### PR DESCRIPTION
`isort`'s `--recursive` flag has been deprecated and a no-op for a long time. It's finally a fatal error, forcing us to remove it.

This also removes the "test_settings.py" arg which points to a file which doesn't exist anymore.

This also contains the result of `make upgrade`.

Note for reviewers: This does NOT need a version bump because it results in no change to the published package.