### PR TITLE
feat: add SupportContactContextRequested filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,17 @@ Unreleased
 ----------
 .. scriv-insert-here
 
+
+.. _changelog-3.10.0:
+
+[3.10.0] - 2026-09-08
+---------------------
+
+Added
+~~~~~
+
+* Added new ``SupportContactContextRequested`` filter
+
 .. _changelog-3.9.0:
 
 [3.9.0] - 2026-08-04

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.9.0"
+__version__ = "3.10.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1936,3 +1936,41 @@ class CourseModePriceRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(user=user, course_mode_data=course_mode_data, price=price)
         return data["user"], data["course_mode_data"], data["price"]
+
+
+class SupportContactContextRequested(OpenEdxPublicFilter):
+    """
+    Filter used to enrich the support contact request context with custom tags.
+
+    Purpose:
+        This filter is triggered when a user submits a support contact request. Pipeline steps
+        can inspect the user to append custom tags to the tags list that will be associated
+        with the support ticket.
+
+    Filter Type:
+        org.openedx.learning.support.contact.context.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: lms/djangoapps/support/views/contact_us.py
+        - Function or Method: ContactUsView.get
+    """
+
+    filter_type = "org.openedx.learning.support.contact.context.requested.v1"
+
+    @classmethod
+    def run_filter(cls, tags: list[str], user: Any) -> tuple[list, Any]:
+        """
+        Process the tags list through the configured pipeline steps.
+
+        Arguments:
+            tags (list[str]): the list of tags to be associated with the support ticket.
+            user (User): the user submitting the support request.
+
+        Returns:
+            tuple[list, Any]:
+                - list: the (possibly modified) tags list.
+                - Any: the Django User object (unchanged).
+        """
+        data = super().run_pipeline(tags=tags, user=user)
+        return data["tags"], data["user"]

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -40,6 +40,7 @@ from openedx_filters.learning.filters import (
     ScheduleQuerySetRequested,
     StudentLoginRequested,
     StudentRegistrationRequested,
+    SupportContactContextRequested,
     VerticalBlockChildRenderStarted,
     VerticalBlockRenderCompleted,
 )
@@ -1168,3 +1169,38 @@ class TestCourseModeFilters(TestCase):
         assert user == result_user
         assert course_mode_data == result_course_mode_data
         assert price == result_price
+
+
+class TestSupportContactContextRequestedFilter(TestCase):
+    """
+    Tests for the SupportContactContextRequested filter.
+    """
+
+    def test_filter_type(self):
+        assert (
+            SupportContactContextRequested.filter_type
+            == "org.openedx.learning.support.contact.context.requested.v1"
+        )
+
+    def test_run_filter_returns_tags_unchanged_when_no_pipeline(self):
+        """
+        With no pipeline steps configured, the tags list and user are returned unchanged.
+        """
+        tags = ["some_tag"]
+        user = Mock()
+
+        result = SupportContactContextRequested.run_filter(tags=tags, user=user)
+
+        assert result == (tags, user)
+
+    @patch(
+        "openedx_filters.tooling.OpenEdxPublicFilter.run_pipeline",
+        return_value={"tags": ["some_tag", "enterprise_learner"], "user": Mock()},
+    )
+    def test_run_filter_returns_tags_from_pipeline(self, mock_run_pipeline):
+        """
+        The (possibly modified) tags list returned by the pipeline is passed through.
+        """
+        result = SupportContactContextRequested.run_filter(tags=["some_tag"], user=Mock())
+
+        assert result == (["some_tag", "enterprise_learner"], mock_run_pipeline.return_value["user"])


### PR DESCRIPTION
ENT-11574

Adds a filter that lets pipeline steps enrich the support-contact tags list:
`SupportContactContextRequested` (`org.openedx.learning.support.contact.context.requested.v1`).

## Related PRs

* openedx/edx-enterprise — pipeline step: https://github.com/openedx/edx-enterprise/pull/2688
* openedx/openedx-platform — call-site swap, merges last: https://github.com/openedx/openedx-platform/pull/39076
* edx/edx-platform — sibling PR: https://github.com/edx/edx-platform/pull/455

## Testing

New: unit tests for the filter class in `openedx_filters/learning/tests/test_filters.py`,
matching the existing per-filter-class test pattern (asserts `run_filter` invokes the pipeline
and returns the expected value).

Locally verified: `pytest openedx_filters/learning/tests/test_filters.py` — 75 passed, 99% line
coverage on `filters.py`. `mypy` clean. `isort --check-only` clean.

## Changelog / version

Bumped `__version__` to `3.10.0` and added a `CHANGELOG.rst` entry, matching current practice
(see #391). Note: #391 is also unmerged and claims 3.10.0 — whichever of us merges second will
need a quick rebase to the next version slot; that's expected/normal, not a blocker.