### PR TITLE
feat: add SupportEnrollmentDataRequested filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,16 @@ Unreleased
 .. scriv-insert-here
 
 
+.. _changelog-3.12.0:
+
+[3.12.0] - 2026-09-08
+----------------------
+
+Added
+~~~~~
+
+* Added new ``SupportEnrollmentDataRequested`` filter
+
 .. _changelog-3.11.0:
 
 [3.11.0] - 2026-09-10

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.11.0"
+__version__ = "3.12.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1971,3 +1971,40 @@ class SupportContactContextRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context)
         return data["context"]
+
+
+class SupportEnrollmentDataRequested(OpenEdxPublicFilter):
+    """
+    Filter used to enrich the support enrollment data.
+
+    Purpose:
+        This filter is triggered when the support enrollment view fetches enrollment data for
+        a user. Pipeline steps can inject additional enrollment records or augment existing ones.
+
+    Filter Type:
+        org.openedx.learning.support.enrollment.data.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: lms/djangoapps/support/views/enrollments.py
+        - Function or Method: EnrollmentSupportListView.get
+    """
+
+    filter_type = "org.openedx.learning.support.enrollment.data.requested.v1"
+
+    @classmethod
+    def run_filter(cls, enrollment_data: dict, user: Any) -> tuple[dict, Any]:
+        """
+        Process the enrollment data dict through the configured pipeline steps.
+
+        Arguments:
+            enrollment_data (dict): dict mapping course_id to list of enrollment records.
+            user (User): the user whose enrollment data is being fetched.
+
+        Returns:
+            tuple[dict, Any]:
+                - dict: the (possibly enriched) enrollment data dict.
+                - Any: the Django User object (unchanged).
+        """
+        data = super().run_pipeline(enrollment_data=enrollment_data, user=user)
+        return data["enrollment_data"], data["user"]

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -41,6 +41,7 @@ from openedx_filters.learning.filters import (
     StudentLoginRequested,
     StudentRegistrationRequested,
     SupportContactContextRequested,
+    SupportEnrollmentDataRequested,
     VerticalBlockChildRenderStarted,
     VerticalBlockRenderCompleted,
 )
@@ -1203,3 +1204,44 @@ class TestSupportContactContextRequestedFilter(TestCase):
         result = SupportContactContextRequested.run_filter(context={"tags": ["some_tag"]})
 
         assert result == mock_run_pipeline.return_value["context"]
+
+
+class TestSupportEnrollmentDataRequestedFilter(TestCase):
+    """
+    Tests for the SupportEnrollmentDataRequested filter.
+    """
+
+    def test_filter_type(self):
+        assert (
+            SupportEnrollmentDataRequested.filter_type
+            == "org.openedx.learning.support.enrollment.data.requested.v1"
+        )
+
+    def test_run_filter_returns_enrollment_data_unchanged_when_no_pipeline(self):
+        """
+        With no pipeline steps configured, the enrollment_data dict and user are returned unchanged.
+        """
+        enrollment_data = {}
+        user = Mock()
+
+        result = SupportEnrollmentDataRequested.run_filter(enrollment_data=enrollment_data, user=user)
+
+        assert result == (enrollment_data, user)
+
+    @patch(
+        "openedx_filters.tooling.OpenEdxPublicFilter.run_pipeline",
+        return_value={
+            "enrollment_data": {"course-v1:edX+DemoX+Demo_Course": [{"course_id": "some-id"}]},
+            "user": Mock(),
+        },
+    )
+    def test_run_filter_returns_enrollment_data_from_pipeline(self, mock_run_pipeline):
+        """
+        The (possibly enriched) enrollment_data dict returned by the pipeline is passed through.
+        """
+        result = SupportEnrollmentDataRequested.run_filter(enrollment_data={}, user=Mock())
+
+        assert result == (
+            {"course-v1:edX+DemoX+Demo_Course": [{"course_id": "some-id"}]},
+            mock_run_pipeline.return_value["user"],
+        )


### PR DESCRIPTION
ENT-11574

Companion PR to the already-open support-contact-tag PR set (openedx-filters#390,
edx-enterprise#2688, openedx-platform#39076, edx-platform#455) — this one covers the
other half of ENT-11574's acceptance criteria: enterprise enrollment data for the support
enrollment view.

Adds `SupportEnrollmentDataRequested` (`org.openedx.learning.support.enrollment.data.requested.v1`)
— lets pipeline steps inject enterprise enrollment data into the support enrollment lookup.

## Related PRs

* openedx/edx-enterprise — pipeline step: https://github.com/openedx/edx-enterprise/pull/2690
* openedx/openedx-platform — call-site swap, merges last: https://github.com/openedx/openedx-platform/pull/39083
* edx/edx-platform — sibling PR: https://github.com/edx/edx-platform/pull/462
* Sibling ticket-half already in review: openedx-filters#390, edx-enterprise#2688,
  openedx-platform#39076, edx-platform#455 (support-contact-tag)

## Testing

New: unit tests for the filter class in `openedx_filters/learning/tests/test_filters.py`,
matching the existing per-filter-class test pattern.

Locally verified: `pytest openedx_filters/learning/tests/test_filters.py` — 75 passed. `mypy`
clean. `isort --check-only` clean.

## Changelog / version

Bumped `__version__` to `3.11.0` (3.10.0 already claimed by the sibling contact-tag PR) and
added a `CHANGELOG.rst` entry, matching current practice.