### PR TITLE
fix: change SupportContactContextRequested to accept/return full context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,18 @@ Unreleased
 .. scriv-insert-here
 
 
+.. _changelog-3.11.0:
+
+[3.11.0] - 2026-09-10
+----------------------
+
+Changed
+~~~~~~~
+
+* Changed ``SupportContactContextRequested`` to accept/return the entire support contact page
+  context dict instead of a bare tags list, and dropped the unused ``user`` argument (fetch it via
+  ``crum`` internally if needed, matching other filters' convention)
+
 .. _changelog-3.10.0:
 
 [3.10.0] - 2026-09-08

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 from openedx_filters.filters import *
 
-__version__ = "3.10.0"
+__version__ = "3.11.0"
 
 if sys.version_info < (3, 12):  # pragma: no cover
     warnings.warn(

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1940,12 +1940,12 @@ class CourseModePriceRequested(OpenEdxPublicFilter):
 
 class SupportContactContextRequested(OpenEdxPublicFilter):
     """
-    Filter used to enrich the support contact request context with custom tags.
+    Filter used to enrich the support contact request context.
 
     Purpose:
         This filter is triggered when a user submits a support contact request. Pipeline steps
-        can inspect the user to append custom tags to the tags list that will be associated
-        with the support ticket.
+        can inspect and modify the support contact page context — e.g. append custom tags to
+        context['tags'] — before the page is rendered and the ticket is associated with those tags.
 
     Filter Type:
         org.openedx.learning.support.contact.context.requested.v1
@@ -1959,18 +1959,15 @@ class SupportContactContextRequested(OpenEdxPublicFilter):
     filter_type = "org.openedx.learning.support.contact.context.requested.v1"
 
     @classmethod
-    def run_filter(cls, tags: list[str], user: Any) -> tuple[list, Any]:
+    def run_filter(cls, context: dict) -> dict:
         """
-        Process the tags list through the configured pipeline steps.
+        Process the support contact page context through the configured pipeline steps.
 
         Arguments:
-            tags (list[str]): the list of tags to be associated with the support ticket.
-            user (User): the user submitting the support request.
+            context (dict): the support contact page template context.
 
         Returns:
-            tuple[list, Any]:
-                - list: the (possibly modified) tags list.
-                - Any: the Django User object (unchanged).
+            dict: the (possibly modified) context dict.
         """
-        data = super().run_pipeline(tags=tags, user=user)
-        return data["tags"], data["user"]
+        data = super().run_pipeline(context=context)
+        return data["context"]

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -1182,25 +1182,24 @@ class TestSupportContactContextRequestedFilter(TestCase):
             == "org.openedx.learning.support.contact.context.requested.v1"
         )
 
-    def test_run_filter_returns_tags_unchanged_when_no_pipeline(self):
+    def test_run_filter_returns_context_unchanged_when_no_pipeline(self):
         """
-        With no pipeline steps configured, the tags list and user are returned unchanged.
+        With no pipeline steps configured, the context dict is returned unchanged.
         """
-        tags = ["some_tag"]
-        user = Mock()
+        context = {"tags": ["some_tag"]}
 
-        result = SupportContactContextRequested.run_filter(tags=tags, user=user)
+        result = SupportContactContextRequested.run_filter(context=context)
 
-        assert result == (tags, user)
+        assert result == context
 
     @patch(
         "openedx_filters.tooling.OpenEdxPublicFilter.run_pipeline",
-        return_value={"tags": ["some_tag", "enterprise_learner"], "user": Mock()},
+        return_value={"context": {"tags": ["some_tag", "enterprise_learner"]}},
     )
-    def test_run_filter_returns_tags_from_pipeline(self, mock_run_pipeline):
+    def test_run_filter_returns_context_from_pipeline(self, mock_run_pipeline):
         """
-        The (possibly modified) tags list returned by the pipeline is passed through.
+        The (possibly modified) context dict returned by the pipeline is passed through.
         """
-        result = SupportContactContextRequested.run_filter(tags=["some_tag"], user=Mock())
+        result = SupportContactContextRequested.run_filter(context={"tags": ["some_tag"]})
 
-        assert result == (["some_tag", "enterprise_learner"], mock_run_pipeline.return_value["user"])
+        assert result == mock_run_pipeline.return_value["context"]


### PR DESCRIPTION
## Description

Addresses [review feedback](https://github.com/edx/edx-platform/pull/455/changes#r3981440210) on the sibling edx-platform PR #455: `SupportContactContextRequested`'s original shape was wrong. It claimed to request the support-contact "context" but only ever passed/returned a bare `tags` list, and accepted a `user` argument that no pipeline step actually needs (it's available via `crum` internally, matching the convention used elsewhere in this codebase).

`run_filter` now takes a single `context: dict` and returns the (possibly modified) context dict directly — no tuple, matching the existing single-input/output pattern already used by filters like `StudentRegistrationRequested`.

Callers are expected to call this **after** populating `context['tags']`, so pipeline steps can read/modify the tags via `context['tags']` in place.

Since the original shape (#390) already merged and released as 3.10.0, this is a new PR rather than an amendment.

## Companion PRs

- edx-enterprise: pipeline step update to match (forthcoming, same PR set)
- openedx-platform / edx-platform: call-site update deferred until this and the edx-enterprise companion PR are released, to avoid breaking their CI against the old pinned version

ENT-11574
